### PR TITLE
Update epoxy boot server to read Host records from Datastore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,9 @@ deploy:
   skip_cleanup: true
   on:
     repo: m-lab/epoxy
+    # Consider all branches and match using the condition. By default
+    # "all_branches" is false, and the condition is ignored.
+    all_branches: true
     # A bash-style 'if' condition, matching branches with a "sandbox-" prefix.
     condition: $TRAVIS_BRANCH == sandbox-*
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+# This is the list of MLab Scraper authors for copyright purposes.
+# #
+# # This does not necessarily list everyone who has contributed code, since in
+# # some cases, their employer may be the copyright holder.  To see the full list
+# # of contributors, see the revision history in source control.
+Google Inc

--- a/README.md
+++ b/README.md
@@ -11,12 +11,18 @@ To build the ePoxy boot server:
 
 ## Testing Server
 
-Start the datastore emulator:
+The datastore emulator depends on the [Google Cloud
+SDK](https://cloud.google.com/sdk/downloads). After installing `gcloud`,
+install the datastore emulator component:
+
+    gcloud components install cloud-datastore-emulator
+
+Next, start the datastore emulator:
 
     gcloud beta emulators datastore start
 
-Look for the `DATASTORE_EMULATOR_HOST` reported on stdout. This should be set
-for all subsequent commands.
+Look for the `DATASTORE_EMULATOR_HOST` reported on stdout. This environment
+variable should be set for all subsequent commands.
 
 Add a sample Host record to the Datastore emulator:
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
-# epoxy
+# ePoxy
 A system for safe boot management over the Internet, based on iPXE.
+
+# Building
+
+To build the ePoxy boot server:
+
+    go get github.com/m-lab/epoxy/cmd/epoxy_boot_server
+
+# Testing
+
+## Testing Server
+
+Start the datastore emulator:
+
+    gcloud beta emulators datastore start
+
+Look for the `DATASTORE_EMULATOR_HOST` reported on stdout. This should be set
+for all subsequent commands.
+
+Add a sample Host record to the Datastore emulator:
+
+    TODO(soltesz): create command to add a minimal host record directly to DS.
+
+Start the epoxy server:
+
+    export DATASTORE_EMULATOR_HOST=< ... >
+    export PUBLIC_ADDRESS=localhost:8080
+    export GCLOUD_PROJECT="my-project"
+    ./bin/epoxy_boot_server
+
+The ePoxy server is now connected to the local datastore emulator, and can
+serve client requests.
+
+## Testing Client
+
+After starting the datastore emuulator and a local epoxy boot server, you can
+simulate a client request using `curl`.
+
+    SERVER=localhost:8080
+    curl --dump-header - --location -XPOST --data-binary "{}" \
+        https://${SERVER}/v1/boot/mlab4.iad1t.measurement-lab.org/stage2.ipxe
+
+If the host record is found in Datastore, then a stage2 boot script should be
+returned. If the host record is not found, then:
+
+    TODO(soltesz): handle 404 cases with a valid ipxe script.
+
+If developing with the mlab-sandbox GCP, then verify that the deployment was
+successful through travis and the AppEngine Cloud Console. Then set the SERVER
+address for the boot-api service. For example, for mlab-sandbox, use:
+
+    SERVER=boot-api-dot-mlab-sandbox.appspot.com

--- a/cmd/epoxy_boot_server/main_test.go
+++ b/cmd/epoxy_boot_server/main_test.go
@@ -15,11 +15,8 @@
 package main
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"strings"
 	"testing"
 )
 
@@ -34,32 +31,5 @@ func TestCheckHealth(t *testing.T) {
 	}
 	if w.Body.String() != "ok" {
 		t.Errorf("wrong health response: got %s want 'ok'", w.Body.String())
-	}
-}
-
-func TestGenerateStage2IPXE(t *testing.T) {
-	r := newRouter()
-	ts := httptest.NewServer(r)
-	defer ts.Close()
-
-	// TODO(soltesz): simulate the values POSTed by an iPXE client.
-	vals := url.Values{}
-	u := ts.URL + "/v1/boot/example.com/stage2.ipxe"
-
-	resp, err := http.PostForm(u, vals)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("wrong status code: got %d want %d", resp.StatusCode, http.StatusOK)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasPrefix(string(body), "#!ipxe") {
-		t.Errorf("wrong script prefix: got '%s' want '#!ipxe'", body[:6])
 	}
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,0 +1,97 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// Package handler provides functions for responding to specific client
+// requests by the ePoxy boot server.
+package handler
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/m-lab/epoxy/storage"
+	"github.com/m-lab/epoxy/template"
+)
+
+// Config provides access to Host records.
+type Config interface {
+	Save(host *storage.Host) error
+	Load(name string) (*storage.Host, error)
+}
+
+// Env holds data necessary for executing handler functions.
+type Env struct {
+	// Config provides access to Host records.
+	Config Config
+	// ServerAddr is the host:port of the public service. Used to generate absolute URLs.
+	ServerAddr string
+}
+
+// Handler objects satisfy the http.Handler interface. A Handler contains an environment
+// for executing the associated handler function.
+type Handler struct {
+	*Env
+	// HandlerFunc handles a request using the included Env.
+	HandlerFunc func(env *Env, rw http.ResponseWriter, req *http.Request) (int, error)
+}
+
+// ServeHTTP satisfies the http.Handler interface.
+func (h Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	code, err := h.HandlerFunc(h.Env, rw, req)
+	if err != nil {
+		http.Error(rw, err.Error(), code)
+	}
+}
+
+// GenerateStage2IPXE creates the stage2 iPXE script for booting machines.
+func GenerateStage2IPXE(env *Env, rw http.ResponseWriter, req *http.Request) (int, error) {
+	hostname := mux.Vars(req)["hostname"]
+
+	// Use hostname as key to load record from Datastore.
+	host, err := env.Config.Load(hostname)
+	if err != nil {
+		return http.StatusNotFound, err
+	}
+	// TODO(soltesz):
+	// * Verify that the source IP maches the host IP.
+	// * Save information sent in PostForm.
+
+	// Generate new session IDs.
+	if err := host.GenerateSessionIDs(); err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	// Save host record to Datastore to commit session IDs.
+	if err := env.Config.Save(host); err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	// Generate iPXE script.
+	script, err := template.FormatStage2IPXEScript(host, env.ServerAddr)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	// Complete request as successful.
+	rw.Header().Set("Content-Type", "text/plain; charset=us-ascii")
+	rw.WriteHeader(http.StatusOK)
+	_, err = fmt.Fprintf(rw, script)
+	if err != nil {
+		log.Printf("Failed to write response to %q: %v", hostname, err)
+	}
+	return http.StatusOK, nil
+}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1,0 +1,128 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package handler
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/m-lab/epoxy/storage"
+)
+
+// fakeConfig is a minimal Config implementation that emulates Host storage with a
+// private field.
+type fakeConfig struct {
+	host *storage.Host
+}
+
+// Save copies the host parameter to the fakeConfig.
+func (f fakeConfig) Save(host *storage.Host) error {
+	*f.host = *host
+	return nil
+}
+
+// Save returns a copy of the fakeConfig host.
+func (f fakeConfig) Load(name string) (*storage.Host, error) {
+	h := &storage.Host{}
+	*h = *f.host
+	return h, nil
+}
+
+// TestGenerateStage2IPXE performs an integration test with an httptest server and a
+// fakeConfig providing Host storage.
+func TestGenerateStage2IPXE(t *testing.T) {
+	// Setup fake server.
+	h := &storage.Host{
+		Name:             "mlab1.iad1t.measurement-lab.org",
+		IPAddress:        "165.117.240.9",
+		Stage2ScriptName: "https://storage.googleapis.com/epoxy-boot-server/stage2/stage2.ipxe",
+	}
+	env := &Env{fakeConfig{h}, "example.com:4321"}
+	router := mux.NewRouter()
+	router.Methods("POST").
+		Path("/v1/boot/{hostname}/stage2.ipxe").
+		Handler(Handler{env, GenerateStage2IPXE})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Run client request.
+	vals := url.Values{}
+	u := ts.URL + "/v1/boot/mlab1.iad1t.measurement-lab.org/stage2.ipxe"
+
+	resp, err := http.PostForm(u, vals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("wrong status code: got %d want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// Read and parse response.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(body)
+	if !strings.HasPrefix(script, "#!ipxe") {
+		lines := strings.SplitN(script, "\n", 2)
+		t.Errorf("Wrong iPXE script prefix: got %q want '#!ipxe'", lines[0])
+	}
+	// Parse the script response to verify generated URLs.
+	urls := make(map[string]*url.URL)
+	lines := strings.Split(script, "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) == 3 {
+			url, err := url.Parse(fields[2])
+			if err != nil {
+				t.Errorf("Failed to parse URL for %s: %q", fields[1], fields[2])
+			}
+			urls[fields[1]] = url
+		}
+	}
+
+	// Define table of expected values.
+	var urlChecks = []struct {
+		name        string
+		host        string
+		partialPath string
+	}{
+		{"stage2_url", "storage.googleapis.com", "epoxy-boot-server/stage2/stage2.ipxe"},
+		{"nextstage_url", "example.com:4321", h.CurrentSessionIDs.NextStageID},
+		{"beginstage_url", "example.com:4321", h.CurrentSessionIDs.BeginStageID},
+		{"endstage_url", "example.com:4321", h.CurrentSessionIDs.EndStageID},
+	}
+	// Assert that all expected values are found.
+	for _, u := range urlChecks {
+		if _, ok := urls[u.name]; !ok {
+			t.Errorf("Missing variable in script: want %q\n", u.name)
+		}
+		url := urls[u.name]
+		if u.host != url.Host {
+			t.Errorf("Wrong host for variable %q; got %q, want %q\n", u.name, url.Host, u.host)
+		}
+		if !strings.Contains(url.Path, u.partialPath) {
+			t.Errorf("Missing portion of URL path for variable %q; got %q, want %q\n",
+				u.name, url.Path, u.partialPath)
+		}
+	}
+}

--- a/storage/datastore.go
+++ b/storage/datastore.go
@@ -1,0 +1,82 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package storage
+
+import (
+	"cloud.google.com/go/datastore"
+	"golang.org/x/net/context"
+)
+
+const (
+	// entityKind categorizes the Datastore records.
+	entityKind = "ePoxyHosts"
+)
+
+// DatastoreConfig contains configuration for accessing Google Cloud Datastore.
+type DatastoreConfig struct {
+	client datastoreClient
+}
+
+// NewDatastoreConfig creates a new DatastoreConfig instance from a *datastore.Client.
+func NewDatastoreConfig(client *datastore.Client) *DatastoreConfig {
+	return &DatastoreConfig{client}
+}
+
+// Load retrieves a Host record from the datastore.
+func (c *DatastoreConfig) Load(name string) (*Host, error) {
+	h := &Host{}
+	key := datastore.NameKey(entityKind, name, nil)
+	if err := c.client.Get(context.Background(), key, h); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// Save stores a Host record to Datastore. Host names are globally unique. If
+// a Host record already exists, then it is overwritten.
+func (c *DatastoreConfig) Save(host *Host) error {
+	key := datastore.NameKey(entityKind, host.Name, nil)
+	if _, err := c.client.Put(context.Background(), key, host); err != nil {
+		return err
+	}
+	return nil
+}
+
+// List retrieves all Host records currently in the Datastore.
+// TODO(soltesz): support some simple query filtering or subsets.
+func (c *DatastoreConfig) List() ([]*Host, error) {
+	var hosts []*Host
+	q := datastore.NewQuery(entityKind)
+	// Discard array of keys returned since we only need the values in hosts.
+	_, err := c.client.GetAll(context.Background(), q, &hosts)
+	if err != nil {
+		return nil, err
+	}
+	return hosts, nil
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Interfaces for testing.
+
+// datastoreClient is a private interface to make testing possible. The default
+// implementation is the actual *datastore.Client as returned by
+// datastore.NewClient. For testing, create a DatastoreConfig initialized with a
+// fake implementation of the datastoreClient interface.
+type datastoreClient interface {
+	Get(ctx context.Context, key *datastore.Key, dst interface{}) error
+	Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error)
+	GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error)
+}

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -1,0 +1,156 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package storage
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/datastore"
+	"golang.org/x/net/context"
+)
+
+// fakeDatastoreClient implements the datastoreClient interface for testing.
+// Every operation should be successful.
+type fakeDatastoreClient struct {
+	host *Host
+}
+
+// Get reads the Host value from f.host and copies it to dst.
+func (f *fakeDatastoreClient) Get(ctx context.Context, key *datastore.Key, dst interface{}) error {
+	// Copy the host from f.host into dst.
+	h, ok := dst.(*Host)
+	if !ok {
+		return fmt.Errorf("type assertion failed: got %T; want *Host", dst)
+	}
+	*h = *f.host
+	return nil
+}
+
+// Put reads the Host value from src and copies it to f.host.
+func (f *fakeDatastoreClient) Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error) {
+	// Copy the host from src into f.host.
+	h, ok := src.(*Host)
+	if !ok {
+		return nil, fmt.Errorf("type assertion failed: got %T; want *Host", src)
+	}
+	*f.host = *h
+	return nil, nil
+}
+
+func (f *fakeDatastoreClient) GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error) {
+	// Extract the pointer to a list of *Host, and append f.host to the list.
+	hosts, ok := dst.(*[]*Host)
+	if !ok {
+		return nil, fmt.Errorf("type assertion failed: got %T; want *[]*Host", dst)
+	}
+	*hosts = append(*hosts, f.host)
+	return nil, nil
+}
+
+// errDatastoreClient implements a datastoreClient interface where every call fails with an error.
+// The error returned is defined in errDatastoreClient.err.
+type errDatastoreClient struct {
+	err error
+}
+
+func (f *errDatastoreClient) Get(ctx context.Context, key *datastore.Key, dst interface{}) error {
+	return f.err
+}
+
+func (f *errDatastoreClient) Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error) {
+	return nil, f.err
+}
+
+func (f *errDatastoreClient) GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error) {
+	return nil, f.err
+}
+
+func TestDatastore(t *testing.T) {
+	// NB: we store a partial Host record for brevity.
+	h := Host{
+		Name:             "mlab1.iad1t.measurement-lab.org",
+		IPAddress:        "165.117.240.9",
+		Stage2ScriptName: "https://example.com/path/stage2/stage2.ipxe",
+		CurrentSessionIDs: SessionIDs{
+			NextStageID: "01234",
+		},
+	}
+	// Declare the fake datastore client outside the function below so we can access member elements.
+	f := &fakeDatastoreClient{&h}
+	c := &DatastoreConfig{f}
+
+	// Store host record.
+	err := c.Save(&h)
+	if err != nil {
+		t.Fatalf("Failed to save host: %s", err)
+	}
+	if !reflect.DeepEqual(&h, f.host) {
+		t.Fatalf("Host records does not match: got %#v; want %#v\n", f.host, &h)
+	}
+
+	// Retrieve host record.
+	h2, err := c.Load("mlab1.iad1t.measurement-lab.org")
+	if err != nil {
+		t.Fatalf("Failed to load host: %s", err)
+	}
+	if !reflect.DeepEqual(&h, h2) {
+		t.Fatalf("Host records does not match: got %#v; want %#v\n", h2, &h)
+	}
+
+	// GetAll all hosts.
+	hosts, err := c.List()
+	if err != nil {
+		t.Fatalf("Failed to list hosts: %s", err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("Failed to list hosts: got %d; want 1\n", len(hosts))
+	}
+}
+
+func TestDatastoreFailures(t *testing.T) {
+	// NB: we store a partial Host record for brevity.
+	h := Host{
+		Name:             "mlab1.iad1t.measurement-lab.org",
+		IPAddress:        "165.117.240.9",
+		Stage2ScriptName: "https://example.com/path/stage2/stage2.ipxe",
+		CurrentSessionIDs: SessionIDs{
+			NextStageID: "01234",
+		},
+	}
+	// Declare the fake datastore client outside the function below so we can access member elements.
+	f := &errDatastoreClient{fmt.Errorf("Fake failure")}
+	c := &DatastoreConfig{f}
+
+	// Store host record.
+	err := c.Save(&h)
+	if err != f.err {
+		t.Fatalf("Saved without error: got %q; want %q\n", err, f.err)
+	}
+
+	// Retrieve host record.
+	_, err = c.Load("mlab1.iad1t.measurement-lab.org")
+	if err != f.err {
+		t.Fatalf("Load without error: got %q; want %q\n", err, f.err)
+	}
+
+	// GetAll all hosts.
+	_, err = c.List()
+	if err != f.err {
+		t.Fatalf("List without error: got %q; want %q\n", err, f.err)
+	}
+}

--- a/storage/host.go
+++ b/storage/host.go
@@ -1,0 +1,121 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// Package storage includes the Host record definition. Host records represent
+// a managed machine and store the next stage configuration. Host records are
+// saved to persistent storage.
+package storage
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"time"
+)
+
+// These variables provide indirection for the default function implementations.
+// Each can be reassigned with an alternate implementation for unit tests.
+var (
+	randRead = rand.Read
+	timeNow  = time.Now
+)
+
+// CollectedInformation stores information received directly from iPXE clients.
+type CollectedInformation struct {
+	Platform         string
+	BuildArch        string
+	Serial           string
+	Asset            string
+	UUID             string
+	Manufacturer     string
+	Product          string
+	Chip             string
+	MAC              string
+	IP               string
+	Version          string
+	PublicSSHHostKey string
+}
+
+// SessionIDs contains the three session IDs generated when requesting a stage2 target.
+type SessionIDs struct {
+	NextStageID  string // Needed for requesting the nextstage.json target.
+	BeginStageID string // Needed for requesting the begingstage target.
+	EndStageID   string // Needed for requesting the endstage target.
+}
+
+// A Host represents the configuration of a server managed by ePoxy.
+type Host struct {
+	// Name is the FQDN of the host.
+	Name string
+	// IPAddress is the IP address the booting machine will use to connect to the API.
+	IPAddress string
+	// Stage2ScriptName is the absolute URL to a stage2 iPXE script.
+	Stage2ScriptName string
+	// NextStageEnabled controls whether ePoxy returns the NextStageScriptName (true)
+	// or DefaultScriptName (false).
+	NextStageEnabled bool
+	// NextStageScriptName is the absolute URL of a JSON next stage configuration.
+	NextStageScriptName string
+	// DefaultScriptName is the absolute URL of a JSON default configuration.
+	DefaultScriptName string
+	// LastSessionIDs are the most recently generated session ids for a booting machine.
+	CurrentSessionIDs SessionIDs
+	// LastSessionCreation is the time when CurrentSessionIDs was generated.
+	LastSessionCreation time.Time
+	// Information reported by the host.
+	CollectedInformation CollectedInformation
+}
+
+// String serializes a Host record. All string type Host fields should be UTF8.
+func (h *Host) String() string {
+	// Errors only occur for non-UTF8 characters in strings.
+	b, _ := json.MarshalIndent(h, "", "    ")
+	return string(b)
+}
+
+// GenerateSessionIDs creates new random session IDs for the host's CurrentSessionIDs.
+// On success, the host LastSessionCreation is updated to the current time.
+func (h *Host) GenerateSessionIDs() error {
+	var err error
+	h.CurrentSessionIDs.NextStageID, err = generateSessionID()
+	if err != nil {
+		return err
+	}
+	h.CurrentSessionIDs.BeginStageID, err = generateSessionID()
+	if err != nil {
+		return err
+	}
+	h.CurrentSessionIDs.EndStageID, err = generateSessionID()
+	if err != nil {
+		return err
+	}
+	h.LastSessionCreation = timeNow()
+	return nil
+}
+
+// randomSessionByteCount is the number of bytes used to generate random session IDs.
+const randomSessionByteCount = 20
+
+// generateSessionId creates a random session ID.
+func generateSessionID() (string, error) {
+	b := make([]byte, randomSessionByteCount)
+	_, err := randRead(b)
+	if err != nil {
+		// Only possible if randRead fails to read len(b) bytes.
+		return "", err
+	}
+	// RawURLEncoding does not pad encoded string with "=".
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/storage/host_test.go
+++ b/storage/host_test.go
@@ -1,0 +1,117 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package storage
+
+import (
+	"log"
+	"testing"
+	"time"
+)
+
+func TestHostString(t *testing.T) {
+	hostExpected := `{
+    "Name": "mlab1.iad1t.measurement-lab.org",
+    "IPAddress": "165.117.240.9",
+    "Stage2ScriptName": "https://storage.googleapis.com/epoxy-boot-server/stage2/stage2.ipxe",
+    "NextStageEnabled": false,
+    "NextStageScriptName": "https://storage.googleapis.com/epoxy-boot-server/centos6/install.json",
+    "DefaultScriptName": "https://storage.googleapis.com/epoxy-boot-server/centos6/boot.json",
+    "CurrentSessionIDs": {
+        "NextStageID": "01234",
+        "BeginStageID": "56789",
+        "EndStageID": "13579"
+    },
+    "LastSessionCreation": "2016-01-02T15:04:00Z",
+    "CollectedInformation": {
+        "Platform": "",
+        "BuildArch": "",
+        "Serial": "",
+        "Asset": "",
+        "UUID": "",
+        "Manufacturer": "",
+        "Product": "",
+        "Chip": "",
+        "MAC": "",
+        "IP": "",
+        "Version": "",
+        "PublicSSHHostKey": ""
+    }
+}`
+
+	lastCreated, err := time.Parse("Jan 2, 2006 at 3:04pm (GMT)", "Jan 2, 2016 at 3:04pm (GMT)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := Host{
+		Name:                "mlab1.iad1t.measurement-lab.org",
+		IPAddress:           "165.117.240.9",
+		Stage2ScriptName:    "https://storage.googleapis.com/epoxy-boot-server/stage2/stage2.ipxe",
+		NextStageScriptName: "https://storage.googleapis.com/epoxy-boot-server/centos6/install.json",
+		DefaultScriptName:   "https://storage.googleapis.com/epoxy-boot-server/centos6/boot.json",
+		CurrentSessionIDs: SessionIDs{
+			NextStageID:  "01234",
+			BeginStageID: "56789",
+			EndStageID:   "13579",
+		},
+		LastSessionCreation: lastCreated,
+	}
+	s := h.String()
+
+	if s != hostExpected {
+		log.Fatalf("Host record does not match: got '%s'; want '%s'\n", s, hostExpected)
+	}
+}
+
+// TestHostGenerateSessionIDs uses a synthetic randRead to generate known IDs and
+// verifies that a host CurrentSessionIDs contains these IDs.
+func TestHostGenerateSessionIDs(t *testing.T) {
+	// Assign a synthetic randRead function to generate known session IDs.
+	randRead = func(b []byte) (n int, err error) {
+		for i := 0; i < len(b); i++ {
+			b[i] = 1
+		}
+		return len(b), nil
+	}
+	lastCreated, err := time.Parse("Jan 2, 2006 at 3:04pm (GMT)", "Jan 2, 2016 at 3:04pm (GMT)")
+	// Assign a synthetic time function to return a known time.
+	timeNow = func() time.Time {
+		return lastCreated
+	}
+	h := &Host{}
+
+	expectedID := "AQEBAQEBAQEBAQEBAQEBAQEBAQE"
+	err = h.GenerateSessionIDs()
+	if err != nil {
+		t.Fatalf("Failed to generate session IDs: %s", err)
+	}
+	if h.CurrentSessionIDs.NextStageID != expectedID {
+		t.Fatalf("Failed to generate NextStageID: got %q; want %q",
+			h.CurrentSessionIDs.NextStageID, expectedID)
+	}
+	if h.CurrentSessionIDs.BeginStageID != expectedID {
+		t.Fatalf("Failed to generate BeginStageID: got %q; want %q",
+			h.CurrentSessionIDs.BeginStageID, expectedID)
+	}
+	if h.CurrentSessionIDs.EndStageID != expectedID {
+		t.Fatalf("Failed to generate EndStageID: got %q; want %q",
+			h.CurrentSessionIDs.EndStageID, expectedID)
+	}
+	expectedTime := "2016-01-02 15:04:00 +0000 UTC"
+	if h.LastSessionCreation.String() != expectedTime {
+		t.Fatalf("Failed to update LastSessionCreation: got %q; want %q",
+			h.LastSessionCreation.String(), expectedTime)
+	}
+}

--- a/template/template.go
+++ b/template/template.go
@@ -1,0 +1,64 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// Package template provides tools for formatting iPXE scripts and JSON configs
+// for ePoxy clients.
+package template
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+
+	"github.com/m-lab/epoxy/storage"
+)
+
+// stage2IpxeTemplate is a template for executing the stage2 iPXE script.
+const stage2IpxeTemplate = `#!ipxe
+
+set stage2_url {{ .Stage2ScriptName }}
+set nextstage_url {{ .NextStageURL }}
+set beginstage_url {{ .BeginStageURL }}
+set endstage_url {{ .EndStageURL }}
+
+chain ${stage2_url}
+`
+
+// FormatStage2IPXEScript generates a stage2 iPXE boot script using values from Host.
+func FormatStage2IPXEScript(h *storage.Host, serverAddr string) (script string, err error) {
+	var b bytes.Buffer
+
+	t, err := template.New("stage2").Parse(stage2IpxeTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare a map
+	vals := make(map[string]string)
+	vals["Stage2ScriptName"] = h.Stage2ScriptName
+	vals["NextStageURL"] = fmt.Sprintf("https://%s/v1/boot/%s/%s/nextstage.json",
+		serverAddr, h.Name, h.CurrentSessionIDs.NextStageID)
+	vals["BeginStageURL"] = fmt.Sprintf("https://%s/v1/boot/%s/%s/beginstage",
+		serverAddr, h.Name, h.CurrentSessionIDs.BeginStageID)
+	vals["EndStageURL"] = fmt.Sprintf("https://%s/v1/boot/%s/%s/endstage",
+		serverAddr, h.Name, h.CurrentSessionIDs.EndStageID)
+
+	err = t.Execute(&b, vals)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package template
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/m-lab/epoxy/storage"
+)
+
+const expectedStage2Script = `#!ipxe
+
+set stage2_url https://example.com/path/stage2/stage2.ipxe
+set nextstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/01234/nextstage.json
+set beginstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/56789/beginstage
+set endstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/86420/endstage
+
+chain ${stage2_url}
+`
+
+// TestFormatStage2IPXEScript formats a stage2 iPXE script for a sample Host record.
+// The result is checked for a valid header and verbatim against the expected content.
+func TestFormatStage2IPXEScript(t *testing.T) {
+	h := &storage.Host{
+		Name:             "mlab1.iad1t.measurement-lab.org",
+		IPAddress:        "165.117.240.9",
+		Stage2ScriptName: "https://example.com/path/stage2/stage2.ipxe",
+		CurrentSessionIDs: storage.SessionIDs{
+			NextStageID:  "01234",
+			BeginStageID: "56789",
+			EndStageID:   "86420",
+		},
+	}
+
+	script, err := FormatStage2IPXEScript(h, "boot-api-mlab-sandbox.appspot.com")
+	if err != nil {
+		t.Fatalf("Failed to create stage2 ipxe script: %s", err)
+	}
+	// Verify the correct script header.
+	if !strings.HasPrefix(script, "#!ipxe") {
+		lines := strings.SplitN(script, "\n", 2)
+		t.Errorf("Wrong iPXE script prefix: got %q want '#!ipxe'", lines[0])
+	}
+	expectedLines := strings.Split(expectedStage2Script, "\n")
+	actualLines := strings.Split(script, "\n")
+	if diff := pretty.Compare(expectedLines, actualLines); diff != "" {
+		t.Errorf("Wrong iPXE script: diff (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This change adds support for:

* A storage package that defines Host records and an interface for storing them in Datastore.
* A template package to format iPXE scripts based on Host records.
* A handler package that defines client handlers, for responding to booting machines.
* An update to `epoxy_boot_server` to use the above packages.

The result of this change is a boot server that runs in AppEngine flexible environments and can serve registered machines from Datastore with a stage2.ipxe script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/3)
<!-- Reviewable:end -->
