### PR TITLE
Add explicit go_import_path to support tests from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@
 #    deployment target.
 #
 language: go
+go_import_path: github.com/m-lab/epoxy
 
 before_install:
 # NB: Encrypted values are not defined in forks or pull requests.


### PR DESCRIPTION
This change adds an explicit `go_import_path` to the .travis.yml config so forked PRs can run tests successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/9)
<!-- Reviewable:end -->
