### PR TITLE
Move Kargs to outer Config struct

### DIFF
--- a/nextboot/example.json
+++ b/nextboot/example.json
@@ -1,4 +1,13 @@
 {
+   "kargs" : {
+      "epoxy.stage3" : "https://boot-api-mlab-staging.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/stage3?session=67890",
+      "epoxy.stage2" : "https://boot-api-mlab-staging.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/stage2?session=12345",
+      "epoxy.report" : "https://boot-api-mlab-staging.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/report?session=abcde",
+      "ide-core.nodma" : "test1",
+      "epoxy.net_hostname" : "mlab1.foo01.measurement-lab.org",
+      "epoxy.net_ipv4" : "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4",
+      "epoxy.net_interface" : "eth0"
+   },
    "v1" : {
       "files" : {
          "vmlinuz" : {
@@ -9,15 +18,6 @@
             "url" : "https://storage.googleapis.com/epoxy-mlab-sandbox/coreos-generic/coreos_custom_pxe_image.cpio.gz",
             "sha256" : "37c0e81be3a24752fcc2bc51c20e8dae897417dfaabbdce3a8b1efc8a2d310c6"
          }
-      },
-      "kargs" : {
-         "epoxy.stage3" : "https://boot-api-mlab-staging.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/stage3?session=67890",
-         "epoxy.stage2" : "https://boot-api-mlab-staging.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/stage2?session=12345",
-         "epoxy.report" : "https://boot-api-mlab-staging.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/report?session=abcde",
-         "ide-core.nodma" : "test1",
-         "epoxy.net_hostname" : "mlab1.foo01.measurement-lab.org",
-         "epoxy.net_ipv4" : "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4",
-         "epoxy.net_interface" : "eth0"
       },
       "commands" : [
          "# Run kexec using the downloaded initram and vmlinuz files. We reconstruct the command line to remove unused flags",

--- a/nextboot/nextboot.go
+++ b/nextboot/nextboot.go
@@ -14,7 +14,7 @@ type Config struct {
 	// examples below.
 	Kargs map[string]string `json:"kargs,omitempty"`
 
-	// V1 action.
+	// V1 specifies an action to be taken by an ePoxy client.
 	V1 *V1 `json:"v1,omitempty"`
 }
 

--- a/nextboot/nextboot.go
+++ b/nextboot/nextboot.go
@@ -2,6 +2,19 @@ package nextboot
 
 // Config contains a nextboot configuration for an ePoxy client.
 type Config struct {
+	// Kargs contains kernel command line parameters, typically read from
+	// /proc/cmdline. Kernel parameters are split on the first `=`, taking the
+	// left hand side as the Kargs key, and the right hand side as the value.
+	// If there is no `=` in the parameter, the entire parameter becomes the
+	// key with an empty value. All keys and values are strings.
+	//
+	// For example, if there were a parameter `ide-core.nodma=0.1`, then Kargs
+	// will contain a key `ide-core.nodma` with a value of `0.1`. Kargs may be
+	// referenced in templates using the `kargs` template function. See more
+	// examples below.
+	Kargs map[string]string `json:"kargs,omitempty"`
+
+	// V1 action.
 	V1 *V1 `json:"v1,omitempty"`
 }
 
@@ -33,18 +46,6 @@ type V1 struct {
 	// that configuration may contain a new Chain URL, but should typically
 	// refer to a config with Commands.
 	Chain string `json:"chain,omitempty"`
-
-	// Kargs contains kernel command line parameters, typically read from
-	// /proc/cmdline. Kernel parameters are split on the first `=`, taking the
-	// left hand side as the Kargs key, and the right hand side as the value.
-	// If there is no `=` in the parameter, the entire parameter becomes the
-	// key with an empty value. All keys and values are strings.
-	//
-	// For example, if there were a parameter `ide-core.nodma=0.1`, then Kargs
-	// will contain a key `ide-core.nodma` with a value of `0.1`. Kargs may be
-	// referenced in templates using the `kargs` template function. See more
-	// examples below.
-	Kargs map[string]string `json:"kargs,omitempty"`
 
 	// Vars contains key/value pairs. Every string value is evaluated as
 	// a template. Every template value may only reference kernel parameters


### PR DESCRIPTION
This change moves the `Kargs` element of the Config.V1 struct to the outer Config struct. This change reflects the fact that Kargs are a property of the local system whereas the V1 action configuration is read from outside the system. Keeping these two data sources separate makes managing them more natural.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/10)
<!-- Reviewable:end -->
