### PR TITLE
Add minimal epoxy_client and first Config methods

### DIFF
--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -31,8 +31,8 @@ func main() {
 	var result string
 
 	flag.Parse()
-	// TODO: optionally retry in a loop until success, or automatically reboot
-	// after 8hrs of failure.
+	// TODO: Optionally retry in a loop until success or 6 hours of
+	// failure have occurred. Automatically reboot after 6 hours of failure.
 	c := &nextboot.Config{}
 
 	b, err := ioutil.ReadFile(*cmdline)
@@ -54,6 +54,7 @@ func main() {
 	// Report a message to the ePoxy server after running.
 	values := url.Values{}
 	// TODO: report additional host information.
+	// TODO: log the evaluate state of c.V1 -- helpful especially for errors.
 	values.Set("message", result)
 
 	err = c.Report(*report, values)

--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -13,7 +13,7 @@ import (
 	"log"
 	"net/url"
 
-	"github.com/stephen-soltesz/epoxy-1/nextboot"
+	"github.com/m-lab/epoxy/nextboot"
 )
 
 var (

--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/url"
+
+	"github.com/stephen-soltesz/epoxy-1/nextboot"
+)
+
+var (
+	cmdline = flag.String("cmdline", "/proc/cmdline",
+		"Read kernel cmdline parameters from the contents of this file.")
+	action = flag.String("action", "epoxy.stage2",
+		"Execute the config loaded from the URL in this kernel parameter.")
+	report = flag.String("report", "epoxy.report",
+		"Report success or errors with the URL in this kernel parameter.")
+	dryrun = flag.Bool("dry-run", false,
+		"Request all configs but do not run commands. May change state in the ePoxy server.")
+)
+
+func main() {
+	var result string
+
+	flag.Parse()
+	// TODO: optionally retry in a loop until success, or automatically reboot
+	// after 8hrs of failure.
+	c := &nextboot.Config{}
+
+	b, err := ioutil.ReadFile(*cmdline)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Trim leading and trailing whitespace, then split on space.
+	// Read and parse parameters from *cmdline.
+	c.ParseCmdline(string(b))
+
+	// Run the config loaded from the action URL.
+	err = c.Run(*action, *dryrun)
+	if err != nil {
+		// Define a successful result.
+		result = err.Error()
+	} else {
+		result = "success"
+	}
+
+	// Report a message to the ePoxy server after running.
+	values := url.Values{}
+	// TODO: report additional host information.
+	values.Set("message", result)
+
+	err = c.Report(*report, values)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Note: we may reboot without depending on the reboot command using:
+	//   echo 1 > /proc/sys/kernel/sysrq
+	//   echo b > /proc/sysrq-trigger
+}

--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -1,3 +1,10 @@
+// epoxy_client is a command line utility for requesting nextboot configurations
+// from the ePoxy server and executing them.
+//
+// epoxy_client should be embedded in initram images served by ePoxy. Once the
+// network is initialized, epoxy_client can complete actions for the current
+// boot stage. i.e. download config from epoxy, download kernel for stage3,
+// kexec kernel.
 package main
 
 import (
@@ -32,7 +39,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Trim leading and trailing whitespace, then split on space.
 	// Read and parse parameters from *cmdline.
 	c.ParseCmdline(string(b))
 

--- a/nextboot/nextboot.go
+++ b/nextboot/nextboot.go
@@ -60,14 +60,12 @@ type V1 struct {
 	//
 	// For compatibility with template lookup, Vars keys must not contain ".".
 	//
-	// Vars supports three value types:
+	// Vars supports two value types:
 	//
 	//   1. string - evaluated as a template.
 	//   2. []string -- as a convenience, an array of strings is first converted
 	//         to a single string by joining each element with a space. After
 	//         converstion the result is evaluated as a template.
-	//   3. map[string]interface{} -- as a convenience, allows creation of
-	//         recursively nested names.
 	//
 	// Other types are ignored.
 	//

--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -1,0 +1,50 @@
+package nextboot
+
+import (
+	"log"
+	"net/url"
+	"strings"
+)
+
+// ParseCmdline parses the contents of `cmdline` as kernel parameters to
+// initialize `Kargs`. The current value of Kargs is unconditionally overwritten.
+func (c *Config) ParseCmdline(cmdline string) error {
+	log.Printf("Parsing kernel parameters from: %s", cmdline)
+
+	// Trim leading and trailing whitespace, then split on spaces.
+	params := strings.Split(strings.Trim(cmdline, " \n"), " ")
+	kargs := make(map[string]string, len(params))
+	for _, param := range params {
+		// For each parameter, split on first `=` if present.
+		keyval := strings.SplitN(param, "=", 2)
+		// Note: an unsupported kernel parameter may not work correctly.
+		// e.g. if a parameter were just "http://foo.com?a=b".
+		if len(keyval) == 2 {
+			kargs[keyval[0]] = keyval[1]
+		} else {
+			// A single value parameter.
+			kargs[keyval[0]] = ""
+		}
+	}
+
+	// Set Kargs to the values we just parsed.
+	c.Kargs = kargs
+	return nil
+}
+
+// Run requests the URL stored in `Kargs[action]` and loads the returned config.
+// After loading the returned config, Run executes the `V1` actions until an
+// error occurs or all commands are successfully executed.
+//
+// If dryrun is true, then configuration commands are printed but not executed.
+// Note that this may change state in the ePoxy server.
+func (c *Config) Run(action string, dryrun bool) error {
+	log.Printf("Loading config from: %s", c.Kargs[action])
+	return nil
+}
+
+// Report reports values to the URL stored in `Kargs[report]`.
+func (c *Config) Report(report string, values url.Values) error {
+	log.Printf("Reporting values to: %s", c.Kargs[report])
+	return nil
+}

--- a/nextboot/v1_test.go
+++ b/nextboot/v1_test.go
@@ -1,0 +1,66 @@
+package nextboot
+
+import (
+	"testing"
+
+	"github.com/kr/pretty"
+)
+
+func TestConfig_ParseCmdline(t *testing.T) {
+	type input struct {
+		cmdline string
+	}
+	type expected struct {
+		Kargs map[string]string
+	}
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		// All tests are expected to succeed.
+		{
+			name:     "single value",
+			input:    "key=val",
+			expected: map[string]string{"key": "val"},
+		},
+		{
+			name:     "single value with extra whitespace",
+			input:    "key=val  \n",
+			expected: map[string]string{"key": "val"},
+		},
+		{
+			name:     "multi-value",
+			input:    "key=val key2=val2",
+			expected: map[string]string{"key": "val", "key2": "val2"},
+		},
+		{
+			name:     "multi-value with multiple equal signs",
+			input:    "key=val key2=val2=val3",
+			expected: map[string]string{"key": "val", "key2": "val2=val3"},
+		},
+		{
+			name:  "multi-value with URL with parameters",
+			input: "key=val url=http://thing.com?a=b&c=d",
+			expected: map[string]string{
+				"key": "val",
+				"url": "http://thing.com?a=b&c=d",
+			},
+		},
+		{
+			name:     "multi-value with special values in key",
+			input:    "key=val ide-core.nodma=0.1",
+			expected: map[string]string{"key": "val", "ide-core.nodma": "0.1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{}
+			c.ParseCmdline(tt.input)
+
+			if diff := pretty.Diff(c.Kargs, tt.expected); len(diff) != 0 {
+				t.Errorf("Config.ParseCmdline() got = %v, want %v", c.Kargs, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change lays the foundation for epoxy client and supporting Config methods for parsing the kernel parameters as well as running the config and reporting the status back to the epoxy server.

This first change include an implementation of `ParseCmdline` with unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/11)
<!-- Reviewable:end -->
