### PR TITLE
Being to implement Run, starting with Chain loading support

### DIFF
--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -94,7 +94,6 @@ func (c *Config) loadConfig(source, method string) error {
 	switch {
 	case strings.HasPrefix(source, "file://"):
 		// Strip off the file:// prefix. Useful for testing and possibly stage1 legacy boot CDs.
-		// data, err = ioutil.ReadFile(source[7:])
 		body, err = os.Open(source[7:])
 	case method == "POST":
 		// TODO: send additional host metadata in values.

--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -90,7 +90,6 @@ func (c *Config) runCommands() error {
 
 func (c *Config) loadConfig(source, method string) error {
 	var err error
-	// var data []byte
 	var body io.ReadCloser
 	switch {
 	case strings.HasPrefix(source, "file://"):
@@ -113,8 +112,6 @@ func (c *Config) loadConfig(source, method string) error {
 	defer body.Close()
 
 	n := &Config{}
-	// fmt.Println(string(data))
-	// err = json.Unmarshal(data, &n)
 	err = json.NewDecoder(body).Decode(&n)
 	if err != nil {
 		return err

--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -135,19 +135,16 @@ func getDownload(source string, timeout time.Duration) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
-// postDownload
 func postDownload(source string, values url.Values, timeout time.Duration) (io.ReadCloser, error) {
 	resp, err := postWithTimeout(source, values, timeout)
 	if err != nil {
 		return nil, err
 	}
-
 	// TODO: what statuses should we support?
 	// Note: the go client automatically handles standard redirects.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("Bad status code: got %d, expected 200 code", resp.StatusCode)
 	}
-
 	return resp.Body, nil
 }
 


### PR DESCRIPTION
This change begins to implement the `Config.Run` method.

In particular, this change adds support for loading configs via the Config.V1.Chain URL. This is typically the first step in an epoxy client action.

This change includes stubbed support for a GET download that will be replaced in later changes with a more generic and robust large file download mechanism. As well, there is a stubbed method for running Config.V1.Commands, that will be completed by later changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/13)
<!-- Reviewable:end -->
