### PR TITLE
Add support for file template evaluation and download

### DIFF
--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -23,7 +23,7 @@ var (
 		"Execute the config loaded from the URL in this kernel parameter.")
 	report = flag.String("report", "epoxy.report",
 		"Report success or errors with the URL in this kernel parameter.")
-	dryrun = flag.Bool("dry-run", false,
+	dryrun = flag.Bool("dryrun", false,
 		"Request all configs but do not run commands. May change state in the ePoxy server.")
 )
 
@@ -57,7 +57,7 @@ func main() {
 	// TODO: log the evaluate state of c.V1 -- helpful especially for errors.
 	values.Set("message", result)
 
-	err = c.Report(*report, values)
+	err = c.Report(*report, values, *dryrun)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -17,13 +17,13 @@ import (
 )
 
 var (
-	cmdline = flag.String("cmdline", "/proc/cmdline",
+	flagCmdline = flag.String("cmdline", "/proc/cmdline",
 		"Read kernel cmdline parameters from the contents of this file.")
-	action = flag.String("action", "epoxy.stage2",
+	flagAction = flag.String("action", "epoxy.stage2",
 		"Execute the config loaded from the URL in this kernel parameter.")
-	report = flag.String("report", "epoxy.report",
+	flagReport = flag.String("report", "epoxy.report",
 		"Report success or errors with the URL in this kernel parameter.")
-	dryrun = flag.Bool("dryrun", false,
+	flagDryrun = flag.Bool("dryrun", false,
 		"Request all configs but do not run commands. May change state in the ePoxy server.")
 )
 
@@ -35,15 +35,15 @@ func main() {
 	// failure have occurred. Automatically reboot after 6 hours of failure.
 	c := &nextboot.Config{}
 
-	b, err := ioutil.ReadFile(*cmdline)
+	b, err := ioutil.ReadFile(*flagCmdline)
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Read and parse parameters from *cmdline.
+	// Read and parse parameters from *flagCmdline.
 	c.ParseCmdline(string(b))
 
 	// Run the config loaded from the action URL.
-	err = c.Run(*action, *dryrun)
+	err = c.Run(*flagAction, *flagDryrun)
 	if err != nil {
 		// Define a successful result.
 		result = err.Error()
@@ -57,7 +57,7 @@ func main() {
 	// TODO: log the evaluate state of c.V1 -- helpful especially for errors.
 	values.Set("message", result)
 
-	err = c.Report(*report, values, *dryrun)
+	err = c.Report(*flagReport, values, *flagDryrun)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -109,7 +109,7 @@ func (c *Config) runCommands(dryrun bool) error {
 	if err != nil {
 		return err
 	}
-	err = c.evaluateFiles(dryrun)
+	err = c.evaluateAndDownloadFiles(dryrun)
 	defer c.cleanupFiles()
 	if err != nil {
 		return err
@@ -211,7 +211,8 @@ func (c *Config) evaluateVars() error {
 	return nil
 }
 
-func (c *Config) evaluateFiles(dryrun bool) error {
+// TODO: separate these operations to allow user-provided "names".
+func (c *Config) evaluateAndDownloadFiles(dryrun bool) error {
 	for name, urlspec := range c.V1.Files {
 		url, ok := urlspec["url"]
 		if !ok {

--- a/nextboot/v1_test.go
+++ b/nextboot/v1_test.go
@@ -718,7 +718,7 @@ func Test_fileDownload(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		csum      string
+		urlspec   map[string]string
 		delay     time.Duration
 		timeout   time.Duration
 		urlPrefix string
@@ -728,8 +728,8 @@ func Test_fileDownload(t *testing.T) {
 			name: "successful-without-checksum",
 		},
 		{
-			name: "successful-checksum",
-			csum: csum,
+			name:    "successful-checksum",
+			urlspec: map[string]string{"sha256": csum},
 		},
 		{
 			// Before sending response, wait 3x the timeout.
@@ -741,7 +741,7 @@ func Test_fileDownload(t *testing.T) {
 		{
 			// csum should contain an invalid character, "-".
 			name:    "bad-checksum",
-			csum:    "bad-" + csum[4:],
+			urlspec: map[string]string{"sha256": "bad-" + csum[4:]},
 			wantErr: true,
 		},
 		{
@@ -766,7 +766,7 @@ func Test_fileDownload(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = fileDownload(tmpfile.Name(), tt.urlPrefix+tsGet.URL, tt.csum, tt.timeout)
+			err = fileDownload(tmpfile.Name(), tt.urlPrefix+tsGet.URL, tt.urlspec, tt.timeout)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fileDownload() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/nextboot/v1_test.go
+++ b/nextboot/v1_test.go
@@ -1,13 +1,17 @@
 package nextboot
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/kr/pretty"
 	"github.com/renstrom/dedent"
@@ -124,7 +128,7 @@ func TestConfig_String(t *testing.T) {
 						"a": "b",
 					},
 					Commands: []interface{}{
-						"/bin/true",
+						"true",
 					},
 				},
 			},
@@ -147,7 +151,7 @@ func TestConfig_String(t *testing.T) {
 				            "a": "b"
 				        },
 				        "commands": [
-				            "/bin/true"
+				            "true"
 				        ]
 				    }
 				}`),
@@ -246,7 +250,7 @@ func TestConfig_Report(t *testing.T) {
 			c := &Config{
 				Kargs: tt.kargs,
 			}
-			if err := c.Report(tt.args.report, tt.args.values); (err != nil) != tt.wantErr {
+			if err := c.Report(tt.args.report, tt.args.values, false); (err != nil) != tt.wantErr {
 				t.Errorf("Config.Report() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -297,7 +301,7 @@ func TestConfig_Run(t *testing.T) {
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(tt.statusGet)
 					// Declare a minimal config with one command.
-					c := &Config{V1: &V1{Commands: []interface{}{"/bin/true okay"}}}
+					c := &Config{V1: &V1{Commands: []interface{}{"true okay"}}}
 					fmt.Fprint(w, c.String())
 				}))
 			tsPost := httptest.NewServer(
@@ -449,11 +453,11 @@ func TestConfig_evaluateCommands(t *testing.T) {
 					"varkey": "varvalue",
 				},
 				Commands: []interface{}{
-					"/bin/true {{.vars.varkey}}",
+					"true {{.vars.varkey}}",
 				},
 			},
 			expValue: []interface{}{
-				[]interface{}{"/bin/true", "varvalue"},
+				[]interface{}{"true", "varvalue"},
 			},
 			wantErr: false,
 		},
@@ -464,11 +468,11 @@ func TestConfig_evaluateCommands(t *testing.T) {
 					"varkey": "varvalue",
 				},
 				Commands: []interface{}{
-					[]interface{}{"/bin/true", "{{.vars.varkey}}"},
+					[]interface{}{"true", "{{.vars.varkey}}"},
 				},
 			},
 			expValue: []interface{}{
-				[]interface{}{"/bin/true", "varvalue"},
+				[]interface{}{"true", "varvalue"},
 			},
 			wantErr: false,
 		},
@@ -476,12 +480,12 @@ func TestConfig_evaluateCommands(t *testing.T) {
 			name: "error-incomplete-quote-in-command",
 			v1: &V1{
 				Commands: []interface{}{
-					"/bin/true 'single quote is incomplete",
+					"true 'single quote is incomplete",
 				},
 			},
 			expValue: []interface{}{
 				// Unchanged.
-				"/bin/true 'single quote is incomplete",
+				"true 'single quote is incomplete",
 			},
 			wantErr: true,
 		},
@@ -489,12 +493,12 @@ func TestConfig_evaluateCommands(t *testing.T) {
 			name: "error-bad-template-in-string-command",
 			v1: &V1{
 				Commands: []interface{}{
-					"/bin/true {{kargs missingquotes}}",
+					"true {{kargs missingquotes}}",
 				},
 			},
 			expValue: []interface{}{
 				// Unchanged.
-				"/bin/true {{kargs missingquotes}}",
+				"true {{kargs missingquotes}}",
 			},
 			wantErr: true,
 		},
@@ -502,12 +506,12 @@ func TestConfig_evaluateCommands(t *testing.T) {
 			name: "error-bad-template-in-array-command",
 			v1: &V1{
 				Commands: []interface{}{
-					[]interface{}{"/bin/true", "{{kargs missingquotes}}"},
+					[]interface{}{"true", "{{kargs missingquotes}}"},
 				},
 			},
 			expValue: []interface{}{
 				// Unchanged.
-				[]interface{}{"/bin/true", "{{kargs missingquotes}}"},
+				[]interface{}{"true", "{{kargs missingquotes}}"},
 			},
 			wantErr: true,
 		},
@@ -539,7 +543,7 @@ func TestConfig_runCommands(t *testing.T) {
 			v1: &V1{
 				Commands: []interface{}{
 					"# This is a comment!",
-					"/bin/true",
+					"true",
 					"# So is this!",
 				},
 			},
@@ -603,9 +607,171 @@ func TestConfig_runCommands(t *testing.T) {
 			c := &Config{
 				V1: tt.v1,
 			}
-			if err := c.runCommands(); (err != nil) != tt.wantErr {
+			if err := c.runCommands(false); (err != nil) != tt.wantErr {
 				t.Errorf("Config.runCommands() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestConfig_evaluateFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		kargs     map[string]string
+		files     map[string]map[string]string
+		expValue  string
+		statusGet int
+		wantErr   bool
+	}{
+		{
+			name:      "success-template-replace-vars",
+			expValue:  "",
+			statusGet: http.StatusOK,
+			files: map[string]map[string]string{
+				"initram": map[string]string{
+					"url": "{{.vars.testurl}}",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "error-url-missing",
+			expValue:  "",
+			statusGet: http.StatusOK,
+			files: map[string]map[string]string{
+				"initram": map[string]string{
+					"missing-url-key": "",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "error-url-download-fails",
+			expValue:  "",
+			statusGet: http.StatusNotFound,
+			files: map[string]map[string]string{
+				"initram": map[string]string{
+					"url": "{{.vars.testurl}}",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "error-template-evaluation-fails",
+			expValue:  "{{kargs missingqoute}}",
+			statusGet: http.StatusOK,
+			files: map[string]map[string]string{
+				"initram": map[string]string{
+					"url": "{{kargs missingqoute}}",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tsGet := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				c := &Config{V1: &V1{Commands: []interface{}{"true okay"}}}
+				w.Header().Set("Content-Length", fmt.Sprint(len(c.String())))
+				w.WriteHeader(tt.statusGet)
+				if r.Method == http.MethodHead {
+					return
+				}
+				fmt.Fprint(w, c.String())
+			}))
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{
+				Kargs: tt.kargs,
+				V1: &V1{
+					Vars: map[string]interface{}{
+						"testurl": tsGet.URL,
+					},
+					Files: tt.files,
+					Commands: []interface{}{
+						"true",
+					},
+				},
+			}
+			if _, ok := c.V1.Files["initram"]["url"]; ok {
+				//	c.V1.Files["initram"]["url"] = tsGet.URL
+				if tt.expValue == "" {
+					tt.expValue = tsGet.URL
+				}
+			}
+			err := c.evaluateFiles(false)
+			if (err != nil) != tt.wantErr || tt.expValue != c.V1.Files["initram"]["url"] {
+				t.Errorf("Config.evaluateFiles() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Config.evaluateFiles() got = %q, want %q",
+					tt.expValue, c.V1.Files["initram"]["url"])
+			}
+			c.cleanupFiles()
+		})
+		tsGet.Close()
+	}
+}
+
+func Test_fileDownload(t *testing.T) {
+	c := &Config{V1: &V1{Commands: []interface{}{"true okay"}}}
+	msg := c.String()
+	sum := sha256.Sum256([]byte(msg))
+	csum := hex.EncodeToString(sum[:])
+
+	tests := []struct {
+		name      string
+		csum      string
+		delay     time.Duration
+		timeout   time.Duration
+		urlPrefix string
+		wantErr   bool
+	}{
+		{
+			name: "successful-without-checksum",
+		},
+		{
+			name: "successful-checksum",
+			csum: csum,
+		},
+		{
+			// Before sending response, wait 3x the timeout.
+			name:    "bad-timeout",
+			delay:   300 * time.Millisecond,
+			timeout: 100 * time.Millisecond,
+			wantErr: true,
+		},
+		{
+			// csum should contain an invalid character, "-".
+			name:    "bad-checksum",
+			csum:    "bad-" + csum[4:],
+			wantErr: true,
+		},
+		{
+			name:      "bad-url",
+			urlPrefix: ":",
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		tsGet := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+				w.WriteHeader(http.StatusOK)
+				if r.Method == http.MethodHead {
+					return
+				}
+				time.Sleep(tt.delay)
+				fmt.Fprint(w, msg)
+			}))
+		t.Run(tt.name, func(t *testing.T) {
+			tmpfile, err := ioutil.TempFile("", tt.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = fileDownload(tmpfile.Name(), tt.urlPrefix+tsGet.URL, tt.csum, tt.timeout)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fileDownload() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			os.Remove(tmpfile.Name())
+		})
+		tsGet.Close()
 	}
 }

--- a/nextboot/v1_test.go
+++ b/nextboot/v1_test.go
@@ -614,7 +614,7 @@ func TestConfig_runCommands(t *testing.T) {
 	}
 }
 
-func TestConfig_evaluateFiles(t *testing.T) {
+func TestConfig_evaluateAndDownloadFiles(t *testing.T) {
 	tests := []struct {
 		name      string
 		kargs     map[string]string
@@ -698,10 +698,10 @@ func TestConfig_evaluateFiles(t *testing.T) {
 					tt.expValue = tsGet.URL
 				}
 			}
-			err := c.evaluateFiles(false)
+			err := c.evaluateAndDownloadFiles(false)
 			if (err != nil) != tt.wantErr || tt.expValue != c.V1.Files["initram"]["url"] {
-				t.Errorf("Config.evaluateFiles() error = %v, wantErr %v", err, tt.wantErr)
-				t.Errorf("Config.evaluateFiles() got = %q, want %q",
+				t.Errorf("Config.evaluateAndDownloadFiles() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Config.evaluateAndDownloadFiles() got = %q, want %q",
 					tt.expValue, c.V1.Files["initram"]["url"])
 			}
 			c.cleanupFiles()


### PR DESCRIPTION
This change completes the last major feature of the epoxy client support for the nextboot.Config.

This change adds support for evaluating the Config.V1.Files URL template and downloading large files locally before executing commands.

This change also adds `-dryrun` support for running commands and reporting status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/15)
<!-- Reviewable:end -->
