### PR TITLE
Use consistent stage1, stage1to2, stage2, etc names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ simulate a client request using `curl`.
 
     SERVER=localhost:8080
     curl --dump-header - --location -XPOST --data-binary "{}" \
-        https://${SERVER}/v1/boot/mlab4.iad1t.measurement-lab.org/stage2.ipxe
+        https://${SERVER}/v1/boot/mlab4.iad1t.measurement-lab.org/stage1.ipxe
 
-If the host record is found in Datastore, then a stage2 boot script should be
+If the host record is found in Datastore, then a stage1 boot script should be
 returned. If the host record is not found, then:
 
     TODO(soltesz): handle 404 cases with a valid ipxe script.

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -18,9 +18,10 @@
 // boot server restricts all state-changing requests to administrative users
 // (any machine) and managed machines (only itself).
 //
-// Managed machines progress through three boot stages: 1) local boot media
-// like an iPXE ROM, or an immutable CD image, 2) a minimal, linux-based
-// network boot environment, 3) the final system image.
+// Managed machines progress through three boot stages:
+//   stage1) local boot media like an iPXE ROM, or an immutable CD image
+//   stage2) a minimal, linux-based network boot environment
+//   stage3) the final system image.
 //
 // Managed machines are treated as stateless. So, the ePoxy boot server acts as
 // an external state manager that mediates the transition of successive boot
@@ -92,15 +93,15 @@ func newRouter(env *handler.Env) *mux.Router {
 	// A health checker for running in Docker or AppEngine.
 	addRoute(router, "GET", "/_ah/health", http.HandlerFunc(checkHealth))
 
-	// Stage2 scripts are always the first script fetched by a booting machine.
-	// "stage2.ipxe" is the target for ROM-based iPXE clients.
-	addRoute(router, "POST", "/v1/boot/{hostname}/stage2.ipxe",
-		handler.Handler{env, handler.GenerateStage2IPXE})
+	// Stage1 scripts are always the first script fetched by a booting machine.
+	// "stage1.ipxe" is the target for ROM-based iPXE clients.
+	addRoute(router, "POST", "/v1/boot/{hostname}/stage1.ipxe",
+		handler.Handler{env, handler.GenerateStage1IPXE})
 
 	// TODO(soltesz): add a target for CD-based ePoxy clients.
-	// addRoute(router, "POST", "/v1/boot/{hostname}/stage2.json", generateStage2Json)
+	// addRoute(router, "POST", "/v1/boot/{hostname}/stage1.json", generateStage1Json)
 
-	// Next, begin, and end stage targets load after stage2 runs successfully.
+	// Next, begin, and end stage targets load after stage1 runs successfully.
 	// TODO(soltesz): add targets for next, begin, and end stage targets.
 	// addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/nextstage.json", generateNextstage)
 	// addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/beginstage", handleBeginStage)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -57,8 +57,8 @@ func (h Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// GenerateStage2IPXE creates the stage2 iPXE script for booting machines.
-func GenerateStage2IPXE(env *Env, rw http.ResponseWriter, req *http.Request) (int, error) {
+// GenerateStage1IPXE creates the stage1 iPXE script for booting machines.
+func GenerateStage1IPXE(env *Env, rw http.ResponseWriter, req *http.Request) (int, error) {
 	hostname := mux.Vars(req)["hostname"]
 
 	// Use hostname as key to load record from Datastore.
@@ -81,7 +81,7 @@ func GenerateStage2IPXE(env *Env, rw http.ResponseWriter, req *http.Request) (in
 	}
 
 	// Generate iPXE script.
-	script, err := template.FormatStage2IPXEScript(host, env.ServerAddr)
+	script, err := template.FormatStage1IPXEScript(host, env.ServerAddr)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -46,26 +46,26 @@ func (f fakeConfig) Load(name string) (*storage.Host, error) {
 	return h, nil
 }
 
-// TestGenerateStage2IPXE performs an integration test with an httptest server and a
+// TestGenerateStage1IPXE performs an integration test with an httptest server and a
 // fakeConfig providing Host storage.
-func TestGenerateStage2IPXE(t *testing.T) {
+func TestGenerateStage1IPXE(t *testing.T) {
 	// Setup fake server.
 	h := &storage.Host{
-		Name:             "mlab1.iad1t.measurement-lab.org",
-		IPAddress:        "165.117.240.9",
-		Stage2ScriptName: "https://storage.googleapis.com/epoxy-boot-server/stage2/stage2.ipxe",
+		Name:                "mlab1.iad1t.measurement-lab.org",
+		IPAddress:           "165.117.240.9",
+		Stage1to2ScriptName: "https://storage.googleapis.com/epoxy-boot-server/stage1to2/stage1to2.ipxe",
 	}
 	env := &Env{fakeConfig{h}, "example.com:4321"}
 	router := mux.NewRouter()
 	router.Methods("POST").
-		Path("/v1/boot/{hostname}/stage2.ipxe").
-		Handler(Handler{env, GenerateStage2IPXE})
+		Path("/v1/boot/{hostname}/stage1.ipxe").
+		Handler(Handler{env, GenerateStage1IPXE})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
 	// Run client request.
 	vals := url.Values{}
-	u := ts.URL + "/v1/boot/mlab1.iad1t.measurement-lab.org/stage2.ipxe"
+	u := ts.URL + "/v1/boot/mlab1.iad1t.measurement-lab.org/stage1.ipxe"
 
 	resp, err := http.PostForm(u, vals)
 	if err != nil {
@@ -106,7 +106,7 @@ func TestGenerateStage2IPXE(t *testing.T) {
 		host        string
 		partialPath string
 	}{
-		{"stage2_url", "storage.googleapis.com", "epoxy-boot-server/stage2/stage2.ipxe"},
+		{"stage1_url", "storage.googleapis.com", "epoxy-boot-server/stage1to2/stage1to2.ipxe"},
 		{"nextstage_url", "example.com:4321", h.CurrentSessionIDs.NextStageID},
 		{"beginstage_url", "example.com:4321", h.CurrentSessionIDs.BeginStageID},
 		{"endstage_url", "example.com:4321", h.CurrentSessionIDs.EndStageID},

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -106,7 +106,7 @@ func TestGenerateStage1IPXE(t *testing.T) {
 		host        string
 		partialPath string
 	}{
-		{"stage1_url", "storage.googleapis.com", "epoxy-boot-server/stage1to2/stage1to2.ipxe"},
+		{"stage1to2_url", "storage.googleapis.com", "epoxy-boot-server/stage1to2/stage1to2.ipxe"},
 		{"nextstage_url", "example.com:4321", h.CurrentSessionIDs.NextStageID},
 		{"beginstage_url", "example.com:4321", h.CurrentSessionIDs.BeginStageID},
 		{"endstage_url", "example.com:4321", h.CurrentSessionIDs.EndStageID},

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -83,9 +83,9 @@ func (f *errDatastoreClient) GetAll(ctx context.Context, q *datastore.Query, dst
 func TestDatastore(t *testing.T) {
 	// NB: we store a partial Host record for brevity.
 	h := Host{
-		Name:             "mlab1.iad1t.measurement-lab.org",
-		IPAddress:        "165.117.240.9",
-		Stage2ScriptName: "https://example.com/path/stage2/stage2.ipxe",
+		Name:                "mlab1.iad1t.measurement-lab.org",
+		IPAddress:           "165.117.240.9",
+		Stage1to2ScriptName: "https://example.com/path/stage1to2/stage1to2.ipxe",
 		CurrentSessionIDs: SessionIDs{
 			NextStageID: "01234",
 		},
@@ -125,9 +125,9 @@ func TestDatastore(t *testing.T) {
 func TestDatastoreFailures(t *testing.T) {
 	// NB: we store a partial Host record for brevity.
 	h := Host{
-		Name:             "mlab1.iad1t.measurement-lab.org",
-		IPAddress:        "165.117.240.9",
-		Stage2ScriptName: "https://example.com/path/stage2/stage2.ipxe",
+		Name:                "mlab1.iad1t.measurement-lab.org",
+		IPAddress:           "165.117.240.9",
+		Stage1to2ScriptName: "https://example.com/path/stage1to2/stage1to2.ipxe",
 		CurrentSessionIDs: SessionIDs{
 			NextStageID: "01234",
 		},

--- a/storage/host.go
+++ b/storage/host.go
@@ -48,7 +48,7 @@ type CollectedInformation struct {
 	PublicSSHHostKey string
 }
 
-// SessionIDs contains the three session IDs generated when requesting a stage2 target.
+// SessionIDs contains the three session IDs generated when requesting a stage1 target.
 type SessionIDs struct {
 	NextStageID  string // Needed for requesting the nextstage.json target.
 	BeginStageID string // Needed for requesting the begingstage target.
@@ -61,8 +61,8 @@ type Host struct {
 	Name string
 	// IPAddress is the IP address the booting machine will use to connect to the API.
 	IPAddress string
-	// Stage2ScriptName is the absolute URL to a stage2 iPXE script.
-	Stage2ScriptName string
+	// Stage1to2ScriptName is the absolute URL to an iPXE script for booting stage1 to stage2.
+	Stage1to2ScriptName string
 	// NextStageEnabled controls whether ePoxy returns the NextStageScriptName (true)
 	// or DefaultScriptName (false).
 	NextStageEnabled bool

--- a/storage/host_test.go
+++ b/storage/host_test.go
@@ -25,7 +25,7 @@ func TestHostString(t *testing.T) {
 	hostExpected := `{
     "Name": "mlab1.iad1t.measurement-lab.org",
     "IPAddress": "165.117.240.9",
-    "Stage2ScriptName": "https://storage.googleapis.com/epoxy-boot-server/stage2/stage2.ipxe",
+    "Stage1to2ScriptName": "https://storage.googleapis.com/epoxy-boot-server/stage1to2/stage1to2.ipxe",
     "NextStageEnabled": false,
     "NextStageScriptName": "https://storage.googleapis.com/epoxy-boot-server/centos6/install.json",
     "DefaultScriptName": "https://storage.googleapis.com/epoxy-boot-server/centos6/boot.json",
@@ -58,7 +58,7 @@ func TestHostString(t *testing.T) {
 	h := Host{
 		Name:                "mlab1.iad1t.measurement-lab.org",
 		IPAddress:           "165.117.240.9",
-		Stage2ScriptName:    "https://storage.googleapis.com/epoxy-boot-server/stage2/stage2.ipxe",
+		Stage1to2ScriptName: "https://storage.googleapis.com/epoxy-boot-server/stage1to2/stage1to2.ipxe",
 		NextStageScriptName: "https://storage.googleapis.com/epoxy-boot-server/centos6/install.json",
 		DefaultScriptName:   "https://storage.googleapis.com/epoxy-boot-server/centos6/boot.json",
 		CurrentSessionIDs: SessionIDs{

--- a/template/template.go
+++ b/template/template.go
@@ -25,29 +25,29 @@ import (
 	"github.com/m-lab/epoxy/storage"
 )
 
-// stage2IpxeTemplate is a template for executing the stage2 iPXE script.
-const stage2IpxeTemplate = `#!ipxe
+// stage1IpxeTemplate is a template for executing the stage1 iPXE script.
+const stage1IpxeTemplate = `#!ipxe
 
-set stage2_url {{ .Stage2ScriptName }}
+set stage1to2_url {{ .Stage1to2ScriptName }}
 set nextstage_url {{ .NextStageURL }}
 set beginstage_url {{ .BeginStageURL }}
 set endstage_url {{ .EndStageURL }}
 
-chain ${stage2_url}
+chain ${stage1to2_url}
 `
 
-// FormatStage2IPXEScript generates a stage2 iPXE boot script using values from Host.
-func FormatStage2IPXEScript(h *storage.Host, serverAddr string) (script string, err error) {
+// FormatStage1IPXEScript generates a stage1 iPXE boot script using values from Host.
+func FormatStage1IPXEScript(h *storage.Host, serverAddr string) (script string, err error) {
 	var b bytes.Buffer
 
-	t, err := template.New("stage2").Parse(stage2IpxeTemplate)
+	t, err := template.New("stage1").Parse(stage1IpxeTemplate)
 	if err != nil {
 		return "", err
 	}
 
 	// Prepare a map
 	vals := make(map[string]string)
-	vals["Stage2ScriptName"] = h.Stage2ScriptName
+	vals["Stage1to2ScriptName"] = h.Stage1to2ScriptName
 	vals["NextStageURL"] = fmt.Sprintf("https://%s/v1/boot/%s/%s/nextstage.json",
 		serverAddr, h.Name, h.CurrentSessionIDs.NextStageID)
 	vals["BeginStageURL"] = fmt.Sprintf("https://%s/v1/boot/%s/%s/beginstage",

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -23,23 +23,23 @@ import (
 	"github.com/m-lab/epoxy/storage"
 )
 
-const expectedStage2Script = `#!ipxe
+const expectedStage1Script = `#!ipxe
 
-set stage2_url https://example.com/path/stage2/stage2.ipxe
+set stage1to2_url https://example.com/path/stage1to2/stage1to2.ipxe
 set nextstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/01234/nextstage.json
 set beginstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/56789/beginstage
 set endstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/86420/endstage
 
-chain ${stage2_url}
+chain ${stage1to2_url}
 `
 
-// TestFormatStage2IPXEScript formats a stage2 iPXE script for a sample Host record.
+// TestFormatStage1IPXEScript formats a stage1 iPXE script for a sample Host record.
 // The result is checked for a valid header and verbatim against the expected content.
-func TestFormatStage2IPXEScript(t *testing.T) {
+func TestFormatStage1IPXEScript(t *testing.T) {
 	h := &storage.Host{
-		Name:             "mlab1.iad1t.measurement-lab.org",
-		IPAddress:        "165.117.240.9",
-		Stage2ScriptName: "https://example.com/path/stage2/stage2.ipxe",
+		Name:                "mlab1.iad1t.measurement-lab.org",
+		IPAddress:           "165.117.240.9",
+		Stage1to2ScriptName: "https://example.com/path/stage1to2/stage1to2.ipxe",
 		CurrentSessionIDs: storage.SessionIDs{
 			NextStageID:  "01234",
 			BeginStageID: "56789",
@@ -47,16 +47,16 @@ func TestFormatStage2IPXEScript(t *testing.T) {
 		},
 	}
 
-	script, err := FormatStage2IPXEScript(h, "boot-api-mlab-sandbox.appspot.com")
+	script, err := FormatStage1IPXEScript(h, "boot-api-mlab-sandbox.appspot.com")
 	if err != nil {
-		t.Fatalf("Failed to create stage2 ipxe script: %s", err)
+		t.Fatalf("Failed to create stage1 ipxe script: %s", err)
 	}
 	// Verify the correct script header.
 	if !strings.HasPrefix(script, "#!ipxe") {
 		lines := strings.SplitN(script, "\n", 2)
 		t.Errorf("Wrong iPXE script prefix: got %q want '#!ipxe'", lines[0])
 	}
-	expectedLines := strings.Split(expectedStage2Script, "\n")
+	expectedLines := strings.Split(expectedStage1Script, "\n")
 	actualLines := strings.Split(script, "\n")
 	if diff := pretty.Compare(expectedLines, actualLines); diff != "" {
 		t.Errorf("Wrong iPXE script: diff (-want +got):\n%s", diff)


### PR DESCRIPTION
This change updates stage names to use a consistent nomenclature.

Previously, stage1 images requested a `stage2.ipxe` target, and this was confusing me since stage1 was reading and running scripts named "stage2". Instead, now stage1 images request stage1 targets, stage2 
images request stage2 tagets, etc.

By example, a boot sequence will look like:
 * stage1 image requests stage1.ipxe from epoxy server
 * epoxy server returns the URL to a stage1to2.ipxe script
 * stage1 runs the stage1to2 script and boots stage2
 * stage2 image requests stage2.json from epoxy server
 * epoxy server returns the URL to a stage2to3.json config
 * stage2 runs the stage2to3 config and boots stage3.
 * ... etc.

The following simple rule should apply now: "a client stage requests the corresponding stage name from the server".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/16)
<!-- Reviewable:end -->
