### PR TITLE
Simplify the GenerateStage1IPXE handler

### DIFF
--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -96,7 +96,7 @@ func newRouter(env *handler.Env) *mux.Router {
 	// Stage1 scripts are always the first script fetched by a booting machine.
 	// "stage1.ipxe" is the target for ROM-based iPXE clients.
 	addRoute(router, "POST", "/v1/boot/{hostname}/stage1.ipxe",
-		handler.Handler{env, handler.GenerateStage1IPXE})
+		http.HandlerFunc(env.GenerateStage1IPXE))
 
 	// TODO(soltesz): add a target for CD-based ePoxy clients.
 	// addRoute(router, "POST", "/v1/boot/{hostname}/stage1.json", generateStage1Json)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -41,30 +41,16 @@ type Env struct {
 	ServerAddr string
 }
 
-// Handler objects satisfy the http.Handler interface. A Handler contains an environment
-// for executing the associated handler function.
-type Handler struct {
-	*Env
-	// HandlerFunc handles a request using the included Env.
-	HandlerFunc func(env *Env, rw http.ResponseWriter, req *http.Request) (int, error)
-}
-
-// ServeHTTP satisfies the http.Handler interface.
-func (h Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	code, err := h.HandlerFunc(h.Env, rw, req)
-	if err != nil {
-		http.Error(rw, err.Error(), code)
-	}
-}
-
 // GenerateStage1IPXE creates the stage1 iPXE script for booting machines.
-func GenerateStage1IPXE(env *Env, rw http.ResponseWriter, req *http.Request) (int, error) {
+// func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) (int, error) {
+func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) {
 	hostname := mux.Vars(req)["hostname"]
 
 	// Use hostname as key to load record from Datastore.
 	host, err := env.Config.Load(hostname)
 	if err != nil {
-		return http.StatusNotFound, err
+		http.Error(rw, err.Error(), http.StatusNotFound)
+		return
 	}
 	// TODO(soltesz):
 	// * Verify that the source IP maches the host IP.
@@ -72,18 +58,22 @@ func GenerateStage1IPXE(env *Env, rw http.ResponseWriter, req *http.Request) (in
 
 	// Generate new session IDs.
 	if err := host.GenerateSessionIDs(); err != nil {
-		return http.StatusInternalServerError, err
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	// Save host record to Datastore to commit session IDs.
 	if err := env.Config.Save(host); err != nil {
-		return http.StatusInternalServerError, err
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
+	// TODO: make FormatStage1IPXEScript never return an error.
 	// Generate iPXE script.
 	script, err := template.FormatStage1IPXEScript(host, env.ServerAddr)
 	if err != nil {
-		return http.StatusInternalServerError, err
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	// Complete request as successful.
@@ -93,5 +83,5 @@ func GenerateStage1IPXE(env *Env, rw http.ResponseWriter, req *http.Request) (in
 	if err != nil {
 		log.Printf("Failed to write response to %q: %v", hostname, err)
 	}
-	return http.StatusOK, nil
+	return
 }


### PR DESCRIPTION
This change updates the epoxy server implementation of the `GenerateStage1IPXE` handler. It turns out that handlers may be receiver methods. This means that the epoxy `Env` type (which includes a reference to the Datastore) may be a receiver type that defines multiple handlers.

Each method can be registered as a handler and access the environment at run time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/17)
<!-- Reviewable:end -->
