### PR TITLE
Remove error return value from template.FormatStage1IPXEScript

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -68,13 +68,8 @@ func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO: make FormatStage1IPXEScript never return an error.
 	// Generate iPXE script.
-	script, err := template.FormatStage1IPXEScript(host, env.ServerAddr)
-	if err != nil {
-		http.Error(rw, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	script := template.FormatStage1IPXEScript(host, env.ServerAddr)
 
 	// Complete request as successful.
 	rw.Header().Set("Content-Type", "text/plain; charset=us-ascii")

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -116,9 +116,9 @@ func TestGenerateStage1IPXE(t *testing.T) {
 		partialPath string
 	}{
 		{"stage1to2_url", "storage.googleapis.com", "epoxy-boot-server/stage1to2/stage1to2.ipxe"},
-		{"nextstage_url", "example.com:4321", h.CurrentSessionIDs.NextStageID},
-		{"beginstage_url", "example.com:4321", h.CurrentSessionIDs.BeginStageID},
-		{"endstage_url", "example.com:4321", h.CurrentSessionIDs.EndStageID},
+		{"stage2_url", "example.com:4321", h.CurrentSessionIDs.NextStageID},
+		{"stage3_url", "example.com:4321", h.CurrentSessionIDs.BeginStageID},
+		{"report_url", "example.com:4321", h.CurrentSessionIDs.EndStageID},
 	}
 	// Assert that all expected values are found.
 	for _, u := range urlChecks {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -20,15 +20,16 @@ import (
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
+
 	"github.com/m-lab/epoxy/storage"
 )
 
 const expectedStage1Script = `#!ipxe
 
 set stage1to2_url https://example.com/path/stage1to2/stage1to2.ipxe
-set nextstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/01234/nextstage.json
-set beginstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/56789/beginstage
-set endstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/86420/endstage
+set stage2_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/01234/stage2.json
+set stage3_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/56789/stage3.json
+set report_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/86420/report
 
 chain ${stage1to2_url}
 `
@@ -47,10 +48,7 @@ func TestFormatStage1IPXEScript(t *testing.T) {
 		},
 	}
 
-	script, err := FormatStage1IPXEScript(h, "boot-api-mlab-sandbox.appspot.com")
-	if err != nil {
-		t.Fatalf("Failed to create stage1 ipxe script: %s", err)
-	}
+	script := FormatStage1IPXEScript(h, "boot-api-mlab-sandbox.appspot.com")
 	// Verify the correct script header.
 	if !strings.HasPrefix(script, "#!ipxe") {
 		lines := strings.SplitN(script, "\n", 2)


### PR DESCRIPTION
Since the ipxe script template is hard coded, if unit tests for `FormatStage1IPXEScript` pass then it is not possible for the template to fail at run time.

In an effort to improve test coverage of `GenerateStage1IPXE` this change removes the error return value from `template.FormatStage1IPXEScript`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/18)
<!-- Reviewable:end -->
