### PR TITLE
Add server support for stage2, stage3, and report targets

### DIFF
--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -101,6 +101,9 @@ func newRouter(env *handler.Env) *mux.Router {
 	// TODO(soltesz): add a target for CD-based ePoxy clients.
 	// addRoute(router, "POST", "/v1/boot/{hostname}/stage1.json", generateStage1Json)
 
+	//TODO: make the names stage2 and stage3 arbitrary when we need to support
+	///the case where not every machine has the same stage2 or stage3
+
 	// Stage2, stage3, and report targets load after stage1 runs successfully.
 	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/stage2",
 		http.HandlerFunc(env.GenerateJSONConfig))

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -101,11 +101,13 @@ func newRouter(env *handler.Env) *mux.Router {
 	// TODO(soltesz): add a target for CD-based ePoxy clients.
 	// addRoute(router, "POST", "/v1/boot/{hostname}/stage1.json", generateStage1Json)
 
-	// Next, begin, and end stage targets load after stage1 runs successfully.
-	// TODO(soltesz): add targets for next, begin, and end stage targets.
-	// addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/nextstage.json", generateNextstage)
-	// addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/beginstage", handleBeginStage)
-	// addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/endstage", handleEndStage)
+	// Stage2, stage3, and report targets load after stage1 runs successfully.
+	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/stage2",
+		http.HandlerFunc(env.GenerateJSONConfig))
+	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/stage3",
+		http.HandlerFunc(env.GenerateJSONConfig))
+	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/report",
+		http.HandlerFunc(env.ReceiveReport))
 
 	// TODO(soltesz): add a target or retrieving all published SSH host keys.
 	// addRoute(router, "GET", "/v1/boot/known_hosts", getKnownHosts)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -68,13 +68,8 @@ func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO: make FormatStage1IPXEScript never return an error.
 	// Generate iPXE script.
-	script, err := template.FormatStage1IPXEScript(host, env.ServerAddr)
-	if err != nil {
-		http.Error(rw, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	script := template.FormatStage1IPXEScript(host, env.ServerAddr)
 
 	// Complete request as successful.
 	rw.Header().Set("Content-Type", "text/plain; charset=us-ascii")

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -79,7 +79,8 @@ func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) {
 	return
 }
 
-// GenerateJSONConfig
+// GenerateJSONConfig creates and returns a JSON serialized nextboot.Config
+// suitable for responding to stage2 or stage3 requests.
 func (env *Env) GenerateJSONConfig(rw http.ResponseWriter, req *http.Request) {
 	hostname := mux.Vars(req)["hostname"]
 	// TODO: Verify that the sessionID matches the host.CurrentSessionIDs.Stage2ID.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -116,9 +116,9 @@ func TestGenerateStage1IPXE(t *testing.T) {
 		partialPath string
 	}{
 		{"stage1to2_url", "storage.googleapis.com", "epoxy-boot-server/stage1to2/stage1to2.ipxe"},
-		{"nextstage_url", "example.com:4321", h.CurrentSessionIDs.NextStageID},
-		{"beginstage_url", "example.com:4321", h.CurrentSessionIDs.BeginStageID},
-		{"endstage_url", "example.com:4321", h.CurrentSessionIDs.EndStageID},
+		{"stage2_url", "example.com:4321", h.CurrentSessionIDs.NextStageID},
+		{"stage3_url", "example.com:4321", h.CurrentSessionIDs.BeginStageID},
+		{"report_url", "example.com:4321", h.CurrentSessionIDs.EndStageID},
 	}
 	// Assert that all expected values are found.
 	for _, u := range urlChecks {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/m-lab/epoxy/nextboot"
 	"github.com/m-lab/epoxy/storage"
 )
 
@@ -189,28 +190,88 @@ func TestEnv_GenerateStage1IPXE(t *testing.T) {
 }
 
 func TestEnv_GenerateJSONConfig(t *testing.T) {
-	type fields struct {
-		Config     Config
-		ServerAddr string
-	}
-	type args struct {
-		rw  http.ResponseWriter
-		req *http.Request
+	h := &storage.Host{
+		Name:     "mlab1.iad1t.measurement-lab.org",
+		IPv4Addr: "165.117.240.9",
+		Boot: storage.Sequence{
+			Stage2ChainURL: "https://storage.googleapis.com/epoxy-boot-server/stage2/stage2.ipxe",
+		},
+		CurrentSessionIDs: storage.SessionIDs{
+			Stage2ID: "12345",
+		},
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
+		name     string
+		config   fakeConfig
+		status   int
+		expected string
 	}{
-	// TODO: Add test cases.
+		{
+			name:     "okay",
+			config:   fakeConfig{host: h, failOnLoad: false, failOnSave: false},
+			status:   http.StatusOK,
+			expected: (&nextboot.Config{V1: &nextboot.V1{Chain: h.Boot.Stage2ChainURL}}).String(),
+		},
+		{
+			name:     "fail-on-load",
+			config:   fakeConfig{host: h, failOnLoad: true, failOnSave: false},
+			status:   http.StatusNotFound,
+			expected: "Failed to load: mlab1.iad1t.measurement-lab.org\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env := &Env{
-				Config:     tt.fields.Config,
-				ServerAddr: tt.fields.ServerAddr,
+			vars := map[string]string{"hostname": h.Name, "sessionId": h.CurrentSessionIDs.Stage2ID}
+			path := "/v1/boot/mlab1.iad1t.measurement-lab.org/12345/stage2"
+			req := httptest.NewRequest("POST", path, nil)
+			rec := httptest.NewRecorder()
+
+			env := &Env{tt.config, "server.com:4321"}
+			req = mux.SetURLVars(req, vars)
+			env.GenerateJSONConfig(rec, req)
+
+			if rec.Code != tt.status {
+				t.Errorf("GenerateJSONConfig() wrong HTTP status: got %v; want %v", rec.Code, tt.status)
 			}
-			env.GenerateJSONConfig(tt.args.rw, tt.args.req)
+			if tt.expected != rec.Body.String() {
+				t.Errorf("GenerateJSONConfig() wrong response: got %v\n; want %v\n", rec.Body.String(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnv_ReceiveReport(t *testing.T) {
+	h := &storage.Host{
+		Name:     "mlab1.iad1t.measurement-lab.org",
+		IPv4Addr: "165.117.240.9",
+		CurrentSessionIDs: storage.SessionIDs{
+			ReportID: "12345",
+		},
+	}
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{
+			name:   "place-holder",
+			status: http.StatusNoContent,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := map[string]string{"hostname": h.Name, "sessionId": h.CurrentSessionIDs.Stage2ID}
+			path := "/v1/boot/mlab1.iad1t.measurement-lab.org/12345/report"
+			req := httptest.NewRequest("POST", path, nil)
+			rec := httptest.NewRecorder()
+
+			env := &Env{fakeConfig{host: h, failOnLoad: false, failOnSave: false}, "server.com:4321"}
+			req = mux.SetURLVars(req, vars)
+			env.ReceiveReport(rec, req)
+
+			if rec.Code != tt.status {
+				t.Errorf("GenerateJSONConfig() wrong HTTP status: got %v; want %v", rec.Code, tt.status)
+			}
+
 		})
 	}
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -60,9 +60,11 @@ func (f fakeConfig) Load(name string) (*storage.Host, error) {
 func TestGenerateStage1IPXE(t *testing.T) {
 	// Setup fake server.
 	h := &storage.Host{
-		Name:                "mlab1.iad1t.measurement-lab.org",
-		IPAddress:           "165.117.240.9",
-		Stage1to2ScriptName: "https://storage.googleapis.com/epoxy-boot-server/stage1to2/stage1to2.ipxe",
+		Name:     "mlab1.iad1t.measurement-lab.org",
+		IPv4Addr: "165.117.240.9",
+		Boot: storage.Sequence{
+			Stage1ChainURL: "https://storage.googleapis.com/epoxy-boot-server/stage1to2/stage1to2.ipxe",
+		},
 	}
 	env := &Env{fakeConfig{host: h}, "example.com:4321"}
 	router := mux.NewRouter()
@@ -115,10 +117,10 @@ func TestGenerateStage1IPXE(t *testing.T) {
 		host        string
 		partialPath string
 	}{
-		{"stage1to2_url", "storage.googleapis.com", "epoxy-boot-server/stage1to2/stage1to2.ipxe"},
-		{"stage2_url", "example.com:4321", h.CurrentSessionIDs.NextStageID},
-		{"stage3_url", "example.com:4321", h.CurrentSessionIDs.BeginStageID},
-		{"report_url", "example.com:4321", h.CurrentSessionIDs.EndStageID},
+		{"stage1chain_url", "storage.googleapis.com", "epoxy-boot-server/stage1to2/stage1to2.ipxe"},
+		{"stage2_url", "example.com:4321", h.CurrentSessionIDs.Stage2ID},
+		{"stage3_url", "example.com:4321", h.CurrentSessionIDs.Stage3ID},
+		{"report_url", "example.com:4321", h.CurrentSessionIDs.ReportID},
 	}
 	// Assert that all expected values are found.
 	for _, u := range urlChecks {
@@ -138,9 +140,11 @@ func TestGenerateStage1IPXE(t *testing.T) {
 
 func TestEnv_GenerateStage1IPXE(t *testing.T) {
 	h := &storage.Host{
-		Name:                "mlab1.iad1t.measurement-lab.org",
-		IPAddress:           "165.117.240.9",
-		Stage1to2ScriptName: "https://storage.googleapis.com/epoxy-boot-server/stage1to2/stage1to2.ipxe",
+		Name:     "mlab1.iad1t.measurement-lab.org",
+		IPv4Addr: "165.117.240.9",
+		Boot: storage.Sequence{
+			Stage1ChainURL: "https://storage.googleapis.com/epoxy-boot-server/stage1to2/stage1to2.ipxe",
+		},
 	}
 	tests := []struct {
 		name   string
@@ -180,6 +184,33 @@ func TestEnv_GenerateStage1IPXE(t *testing.T) {
 			if rec.Code != tt.status {
 				t.Errorf("GenerateStage1IPXE() wrong HTTP status: got %v; want %v", rec.Code, tt.status)
 			}
+		})
+	}
+}
+
+func TestEnv_GenerateJSONConfig(t *testing.T) {
+	type fields struct {
+		Config     Config
+		ServerAddr string
+	}
+	type args struct {
+		rw  http.ResponseWriter
+		req *http.Request
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &Env{
+				Config:     tt.fields.Config,
+				ServerAddr: tt.fields.ServerAddr,
+			}
+			env.GenerateJSONConfig(tt.args.rw, tt.args.req)
 		})
 	}
 }

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -83,11 +83,13 @@ func (f *errDatastoreClient) GetAll(ctx context.Context, q *datastore.Query, dst
 func TestDatastore(t *testing.T) {
 	// NB: we store a partial Host record for brevity.
 	h := Host{
-		Name:                "mlab1.iad1t.measurement-lab.org",
-		IPAddress:           "165.117.240.9",
-		Stage1to2ScriptName: "https://example.com/path/stage1to2/stage1to2.ipxe",
+		Name:     "mlab1.iad1t.measurement-lab.org",
+		IPv4Addr: "165.117.240.9",
+		Boot: Sequence{
+			Stage1ChainURL: "https://example.com/path/stage1to2/stage1to2.ipxe",
+		},
 		CurrentSessionIDs: SessionIDs{
-			NextStageID: "01234",
+			Stage2ID: "01234",
 		},
 	}
 	// Declare the fake datastore client outside the function below so we can access member elements.
@@ -125,11 +127,13 @@ func TestDatastore(t *testing.T) {
 func TestDatastoreFailures(t *testing.T) {
 	// NB: we store a partial Host record for brevity.
 	h := Host{
-		Name:                "mlab1.iad1t.measurement-lab.org",
-		IPAddress:           "165.117.240.9",
-		Stage1to2ScriptName: "https://example.com/path/stage1to2/stage1to2.ipxe",
+		Name:     "mlab1.iad1t.measurement-lab.org",
+		IPv4Addr: "165.117.240.9",
+		Boot: Sequence{
+			Stage1ChainURL: "https://example.com/path/stage1to2/stage1to2.ipxe",
+		},
 		CurrentSessionIDs: SessionIDs{
-			NextStageID: "01234",
+			Stage2ID: "01234",
 		},
 	}
 	// Declare the fake datastore client outside the function below so we can access member elements.

--- a/storage/host.go
+++ b/storage/host.go
@@ -55,16 +55,18 @@ type SessionIDs struct {
 	ReportID string // Needed for requesting the endstage target.
 }
 
-// Sequence ...
+// Sequence represents a set of operator-provided iPXE scripts or JSON nextboot Configs.
 type Sequence struct {
-	// Stage1ChainURL is the absolute URL to an iPXE script for booting stage1 to stage2.
-	Stage1ChainURL string // boot stage2 image
-	// Stage2ChainURL is the absolute URL to a JSON config for booting stage2 to stage3.
-	Stage2ChainURL string // boot stage3 update image, or coreos
-	// Stage3ChainURL is the absolute URL to a JSON config for running commands in stage3.
-	Stage3ChainURL string // flashrom, or join global k8s cluster.
+	// Stage1ChainURL is the absolute URL to an iPXE script for booting from stage1 to stage2.
+	Stage1ChainURL string
+	// Stage2ChainURL is the absolute URL to a JSON config for booting from stage2 to stage3.
+	Stage2ChainURL string
+	// Stage3ChainURL is the absolute URL to a JSON config for running commands in stage3. For
+	// example, "flashrom", or "join global k8s cluster".
+	Stage3ChainURL string
 }
 
+// NextURL returns the Chain URL corresponding to the given stage name.
 func (s Sequence) NextURL(stage string) string {
 	switch stage {
 	case "stage1":
@@ -86,7 +88,9 @@ type Host struct {
 	// IPv4Addr is the IPv4 address the booting machine will use to connect to the API.
 	IPv4Addr string
 
-	Boot   Sequence
+	// Boot is the typical boot sequence for this Host.
+	Boot Sequence
+	// Update is an alternate boot sequence, typically used to update the system, e.g. reinstall, reflash.
 	Update Sequence
 
 	// UpdateEnabled controls whether ePoxy returns the Update Sequence (true)

--- a/storage/host.go
+++ b/storage/host.go
@@ -48,12 +48,19 @@ type CollectedInformation struct {
 	PublicSSHHostKey string
 }
 
+// TODO: SessionIDs and Sequence structs should be map[string]string, that
+// store target stage names as keys. This prevents hard-coding the target names,
+// the SessionID names and the Sequence stage names.
+
 // SessionIDs contains the three session IDs generated when requesting a stage1 target.
 type SessionIDs struct {
-	Stage2ID string // Needed for requesting the nextstage.json target.
-	Stage3ID string // Needed for requesting the begingstage target.
-	ReportID string // Needed for requesting the endstage target.
+	Stage2ID string // Needed for requesting the stage2.json target.
+	Stage3ID string // Needed for requesting the stage3.json target.
+	ReportID string // Needed for requesting the report target.
 }
+
+// TODO: Sequences could be a separate type stored in datastore. These could be
+// named and referenced by Host objects by name.
 
 // Sequence represents a set of operator-provided iPXE scripts or JSON nextboot Configs.
 type Sequence struct {

--- a/storage/host.go
+++ b/storage/host.go
@@ -136,7 +136,6 @@ func generateSessionID() string {
 		// Only possible if randRead fails to read len(b) bytes.
 		panic(err)
 	}
-	// Return a fixed-format base32 hex encoding of the random bytes.
-	// return base32.StdEncoding.EncodeToString(b)
+	// RawURLEncoding does not pad encoded string with "=".
 	return base64.RawURLEncoding.EncodeToString(b)
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -26,25 +26,27 @@ import (
 
 const expectedStage1Script = `#!ipxe
 
-set stage1to2_url https://example.com/path/stage1to2/stage1to2.ipxe
-set stage2_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/01234/stage2.json
-set stage3_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/56789/stage3.json
+set stage1chain_url https://example.com/path/stage1to2/stage1to2.ipxe
+set stage2_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/01234/stage2
+set stage3_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/56789/stage3
 set report_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/86420/report
 
-chain ${stage1to2_url}
+chain ${stage1chain_url}
 `
 
 // TestFormatStage1IPXEScript formats a stage1 iPXE script for a sample Host record.
 // The result is checked for a valid header and verbatim against the expected content.
 func TestFormatStage1IPXEScript(t *testing.T) {
 	h := &storage.Host{
-		Name:                "mlab1.iad1t.measurement-lab.org",
-		IPAddress:           "165.117.240.9",
-		Stage1to2ScriptName: "https://example.com/path/stage1to2/stage1to2.ipxe",
+		Name:     "mlab1.iad1t.measurement-lab.org",
+		IPv4Addr: "165.117.240.9",
+		Boot: storage.Sequence{
+			Stage1ChainURL: "https://example.com/path/stage1to2/stage1to2.ipxe",
+		},
 		CurrentSessionIDs: storage.SessionIDs{
-			NextStageID:  "01234",
-			BeginStageID: "56789",
-			EndStageID:   "86420",
+			Stage2ID: "01234",
+			Stage3ID: "56789",
+			ReportID: "86420",
 		},
 	}
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -20,15 +20,16 @@ import (
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
+
 	"github.com/m-lab/epoxy/storage"
 )
 
 const expectedStage1Script = `#!ipxe
 
 set stage1to2_url https://example.com/path/stage1to2/stage1to2.ipxe
-set nextstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/01234/nextstage.json
-set beginstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/56789/beginstage
-set endstage_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/86420/endstage
+set stage2_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/01234/stage2.json
+set stage3_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/56789/stage3.json
+set report_url https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.iad1t.measurement-lab.org/86420/report
 
 chain ${stage1to2_url}
 `
@@ -47,10 +48,7 @@ func TestFormatStage1IPXEScript(t *testing.T) {
 		},
 	}
 
-	script, err := FormatStage1IPXEScript(h, "boot-api-mlab-sandbox.appspot.com")
-	if err != nil {
-		t.Fatalf("Failed to create stage1 ipxe script: %s", err)
-	}
+	script := FormatStage1IPXEScript(h, "boot-api-mlab-sandbox.appspot.com")
 	// Verify the correct script header.
 	if !strings.HasPrefix(script, "#!ipxe") {
 		lines := strings.SplitN(script, "\n", 2)


### PR DESCRIPTION
This change adds new targets to the epoxy server for handling stage2, stage3, and report.

This change includes significant revisions to the storage.Host type and associated tests. These name updates are needed to support a three stage boot sequence (previously two were planned).

Additionally, this change removes the propagation of errors due to failed reads from `rand.Reader`. These reads are extremely unlikely in normal environments, and even in those cases, the panic will cause the HTTP request to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/27)
<!-- Reviewable:end -->
