### PR TITLE
Report result to command line

### DIFF
--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -46,10 +46,11 @@ func main() {
 	err = c.Run(*flagAction, *flagDryrun)
 	if err != nil {
 		// Define a successful result.
-		result = err.Error()
+		result = "error: " + err.Error()
 	} else {
 		result = "success"
 	}
+	log.Println("Result:", result)
 
 	// Report a message to the ePoxy server after running.
 	values := url.Values{}


### PR DESCRIPTION
This change adds an additional log line with the result of running the epoxy client action.

Previously without logging, the action was clearly failing, but the error message was only visible in the server logs. This should more easily report errors to the user during debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/30)
<!-- Reviewable:end -->
