### PR TITLE
Do not cancel context before download is complete

### DIFF
--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -533,8 +533,9 @@ func postWithTimeout(url string, values url.Values, timeout time.Duration) (*htt
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel() // cancel the context if Do() returns before timeout.
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	// TODO: handle timeout cancel appropriately. https://github.com/m-lab/epoxy/issues/34
+	// defer cancel() // cancel the context if Do() returns before timeout.
 	req = req.WithContext(ctx)
 
 	client := &http.Client{}


### PR DESCRIPTION
This PR disables a premature context `cancel`. This is not the correct resolution to this problem. But, the correct resolution will be tracked in https://github.com/m-lab/epoxy/issues/34

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/35)
<!-- Reviewable:end -->
