### PR TITLE
Disable `UpdateEnabled` on successful `report`.

### DIFF
--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -105,11 +105,11 @@ func newRouter(env *handler.Env) *mux.Router {
 	///the case where not every machine has the same stage2 or stage3
 
 	// Stage2, stage3, and report targets load after stage1 runs successfully.
-	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/stage2",
+	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionID}/stage2",
 		http.HandlerFunc(env.GenerateJSONConfig))
-	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/stage3",
+	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionID}/stage3",
 		http.HandlerFunc(env.GenerateJSONConfig))
-	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionId}/report",
+	addRoute(router, "POST", "/v1/boot/{hostname}/{sessionID}/report",
 		http.HandlerFunc(env.ReceiveReport))
 
 	// TODO(soltesz): add a target or retrieving all published SSH host keys.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -118,8 +118,6 @@ func (env *Env) GenerateJSONConfig(rw http.ResponseWriter, req *http.Request) {
 func (env *Env) ReceiveReport(rw http.ResponseWriter, req *http.Request) {
 	// TODO: log or save values where appropriate.
 	req.ParseForm()
-	// b, err := ioutil.ReadAll(req.Body)
-	// fmt.Println(string(b))
 
 	// Use hostname as key to load record from Datastore.
 	hostname := mux.Vars(req)["hostname"]
@@ -144,6 +142,7 @@ func (env *Env) ReceiveReport(rw http.ResponseWriter, req *http.Request) {
 		// When the status is success, disable the "update" and mark the time.
 		host.LastSuccess = host.LastReport
 		host.UpdateEnabled = false
+		// TODO: invalidate session ids.
 	}
 
 	// Save the new host state.
@@ -152,10 +151,8 @@ func (env *Env) ReceiveReport(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log.Println(`{"severity": "okay", "message": "this is a test"}`)
-	// TODO: log these values better...
+	// TODO: log using structured JSON.
 	log.Println(req.PostForm)
-	// TODO: invalidate session ids.
 
 	// Report success with no content.
 	rw.WriteHeader(http.StatusNoContent)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -134,8 +134,6 @@ func (env *Env) ReceiveReport(rw http.ResponseWriter, req *http.Request) {
 
 	host.LastReport = time.Now()
 	status := req.PostForm.Get("message")
-	fmt.Println("status:", status)
-	fmt.Println(req.PostForm)
 	if status == "success" {
 		// When the status is success, disable the "update" and mark the time.
 		host.LastSuccess = host.LastReport

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -48,8 +48,6 @@ type Env struct {
 func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) {
 	hostname := mux.Vars(req)["hostname"]
 
-	log.Println(`{"severity": "okay", "message": "this is a test"}`)
-
 	// Use hostname as key to load record from Datastore.
 	host, err := env.Config.Load(hostname)
 	if err != nil {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -114,6 +114,7 @@ func (env *Env) GenerateJSONConfig(rw http.ResponseWriter, req *http.Request) {
 // success or failure. In both cases, the session ids are invalidated. In all cases,
 // epoxy_client is expected to report the server's public host key.
 func (env *Env) ReceiveReport(rw http.ResponseWriter, req *http.Request) {
+	// TODO: Verify that the source IP maches the host IP.
 	// TODO: log or save values where appropriate.
 	req.ParseForm()
 

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -301,7 +301,7 @@ func TestEnv_ReceiveReport(t *testing.T) {
 			}
 
 			if h.UpdateEnabled != tt.expectedEnabled {
-				t.Errorf("ReceiveReport() failed to change UpdateEnable: got %t; want %t",
+				t.Errorf("ReceiveReport() failed to change UpdateEnabled: got %t; want %t",
 					h.UpdateEnabled, tt.expectedEnabled)
 			}
 		})

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -221,7 +221,7 @@ func TestEnv_GenerateJSONConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vars := map[string]string{"hostname": h.Name, "sessionId": h.CurrentSessionIDs.Stage2ID}
+			vars := map[string]string{"hostname": h.Name, "sessionID": h.CurrentSessionIDs.Stage2ID}
 			path := "/v1/boot/mlab1.iad1t.measurement-lab.org/12345/stage2"
 			req := httptest.NewRequest("POST", path, nil)
 			rec := httptest.NewRecorder()
@@ -259,7 +259,7 @@ func TestEnv_ReceiveReport(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vars := map[string]string{"hostname": h.Name, "sessionId": h.CurrentSessionIDs.Stage2ID}
+			vars := map[string]string{"hostname": h.Name, "sessionID": h.CurrentSessionIDs.ReportID}
 			path := "/v1/boot/mlab1.iad1t.measurement-lab.org/12345/report"
 			req := httptest.NewRequest("POST", path, nil)
 			rec := httptest.NewRecorder()

--- a/storage/host.go
+++ b/storage/host.go
@@ -108,6 +108,10 @@ type Host struct {
 	CurrentSessionIDs SessionIDs
 	// LastSessionCreation is the time when CurrentSessionIDs was generated.
 	LastSessionCreation time.Time
+	// LastReport is the time of the most recent report for this host.
+	LastReport time.Time
+	// LastSuccess is the time of the most recent successful report from this host.
+	LastSuccess time.Time
 	// CollectedInformation reported by the host.
 	CollectedInformation CollectedInformation
 }

--- a/storage/host_test.go
+++ b/storage/host_test.go
@@ -42,6 +42,8 @@ func TestHostString(t *testing.T) {
         "ReportID": "13579"
     },
     "LastSessionCreation": "2016-01-02T15:04:00Z",
+    "LastReport": "0001-01-01T00:00:00Z",
+    "LastSuccess": "0001-01-01T00:00:00Z",
     "CollectedInformation": {
         "Platform": "",
         "BuildArch": "",


### PR DESCRIPTION
This change adds support for disabling the `Host.UpdateEnabled` flag when the client reports success (after completing the final boot stage).

UpdateEnabled selects between the values in `Host.BootSequence` (false) or `Host.UpdateSequence` (true).

For example, with this feature, it will be possible to configure separate "update" and "boot" sequences that toggle automatically on success: e.g. "Update the MLX ROM" and on success "Boot CoreOS".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/36)
<!-- Reviewable:end -->
