### PR TITLE
Define extension.WebhookRequest & ExtensionOperation types

### DIFF
--- a/extension/webhook.go
+++ b/extension/webhook.go
@@ -1,0 +1,58 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// Package extention defines the Extension Webhook API used between the ePoxy
+// server and extension services.
+package extension
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// WebhookRequest contains information about a booting machine
+type WebhookRequest struct {
+
+	// V1 contains information to send to an extension service.
+	V1 *V1 `json:"v1,omitempty"`
+}
+
+// V1 contains information about a booting machine. The ePoxy server guarantees
+// that a booting machine is registered and all requests have used valid session IDs.
+type V1 struct {
+	// Hostname is the FQDN for the booting machine.
+	Hostname string `json:"hostname"`
+
+	// IPv4Address is the IPv4 address the booting machine.
+	IPv4Address string `json:"ipv4_address"`
+
+	// IPv6Address is the IPv6 address the booting machine.
+	IPv6Address string `json:"ipv6_address"`
+
+	// LastBoot is the most recent time when the booting machine reached stage1.
+	LastBoot time.Time `json:"last_boot"`
+}
+
+// Encode marshals a WebhookRequest to JSON.
+func (req *WebhookRequest) Encode() string {
+	// Errors only occur for non-UTF8 characters in strings or unmarshalable types (which we don't have).
+	b, _ := json.MarshalIndent(req, "", "    ")
+	return string(b)
+}
+
+// Decode unmarshals a WebhookRequest from a JSON message.
+func (req *WebhookRequest) Decode(message []byte) error {
+	return json.Unmarshal(message, req)
+}

--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -1,0 +1,37 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+package storage
+
+// ExtentionOperation maps an operation name (used in URLs) to an extension service URL.
+type ExtentionOperation struct {
+	// Name is the operation name. This will appear in URLs to the ePoxy server.
+	// Name should only use characters [a-zA-Z0-9].
+	Name string
+
+	// URL references a service that implements the extension operation. During
+	// machine boot, when a machine requests the ePoxy extension URL, the ePoxy
+	// server will, in turn, issue a request to this URL, sending an
+	// extension.WebhookRequest message. The extension service response is
+	// returned to the client verbatim.
+	URL string
+}
+
+var (
+	// TODO: save/retrieve extension configuration in/from datastore.
+	// This static map is for preliminary testing.
+	Extensions map[string]string = map[string]string{
+		"k8stoken": "http://k8s-platform-master.mlab-sandbox.measurementlab.net:8000",
+	}
+)


### PR DESCRIPTION
This change adds two new types needed to implement the ePoxy extension API.

The `ExtensionOperation` defines mappings from simple operation names (used in URLs) to the service implementing the extension. When a booting machine requests an epoxy extension URL, after validating the request, the server will send a `WebhookRequest` to the extension URL.

Servers implementing an extension can use `WebhookRequest.Decode` to parse a request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/39)
<!-- Reviewable:end -->
