### PR TITLE
Add example extension server

### DIFF
--- a/cmd/example_extension_server/main.go
+++ b/cmd/example_extension_server/main.go
@@ -1,0 +1,74 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// The example_extension_server demonstrates how a simple HTTP server
+// can receive and respond to requests from the ePoxy server's extension API.
+//
+// The ePoxy server must have an extension registered that maps an operation name
+// to this server, e.g. "operation" -> "http://localhost:8001/operation"
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/m-lab/epoxy/extension"
+)
+
+// Definition of return message. This may have any structure.
+type returnMessage struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// operationHandler is an http.HandlerFunc for responding to an epoxy extension
+// WebhookRequest.
+func operationHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: verify this is a POST request.
+	// TODO: verify this is from a trusted source.
+	var result *returnMessage
+
+	// Decode the webhook request.
+	ext := &extension.WebhookRequest{}
+	err := ext.Decode(r.Body)
+	// Prepare and respond to caller.
+	if err != nil {
+		result = &returnMessage{
+			Status:  "error",
+			Message: err.Error(),
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	} else {
+		fmt.Println("Request:", ext.Encode())
+		result = &returnMessage{
+			Status:  "success",
+			Message: time.Now().String(),
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	raw, _ := json.MarshalIndent(result, "", "    ")
+	w.Write(raw)
+
+	// Log data sent to caller.
+	fmt.Println("Response:", string(raw))
+}
+
+func main() {
+	http.HandleFunc("/operation", operationHandler)
+	log.Fatal(http.ListenAndServe(":8001", nil))
+}

--- a/extension/webhook.go
+++ b/extension/webhook.go
@@ -19,6 +19,8 @@ package extension
 
 import (
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"time"
 )
 
@@ -53,6 +55,10 @@ func (req *WebhookRequest) Encode() string {
 }
 
 // Decode unmarshals a WebhookRequest from a JSON message.
-func (req *WebhookRequest) Decode(message []byte) error {
-	return json.Unmarshal(message, req)
+func (req *WebhookRequest) Decode(msg io.Reader) error {
+	raw, err := ioutil.ReadAll(msg)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, req)
 }

--- a/extension/webhook_test.go
+++ b/extension/webhook_test.go
@@ -1,0 +1,110 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+package extension
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/renstrom/dedent"
+)
+
+func TestWebhookRequest_Encode(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   *V1
+		want string
+	}{
+		{
+			name: "encode-successful",
+			v1: &V1{
+				Hostname:    "mlab4.lga0t.measurement-lab.org",
+				IPv4Address: "192.168.0.12",
+				LastBoot:    time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+			want: dedent.Dedent(`
+        {
+            "v1": {
+                "hostname": "mlab4.lga0t.measurement-lab.org",
+                "ipv4_address": "192.168.0.12",
+                "ipv6_address": "",
+                "last_boot": "2018-05-01T00:00:00Z"
+            }
+        }`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &WebhookRequest{
+				V1: tt.v1,
+			}
+			if got := req.Encode(); got != tt.want[1:] {
+				t.Errorf("WebhookRequest.Encode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebhookRequest_Decode(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      io.Reader
+		wantErr  bool
+		expected *V1
+	}{
+		{
+			name: "decode-successful",
+			msg: ioutil.NopCloser(strings.NewReader(dedent.Dedent(`
+        {
+            "v1": {
+                "hostname": "mlab4.lga0t.measurement-lab.org",
+                "ipv4_address": "192.168.0.12",
+                "ipv6_address": "",
+                "last_boot": "2018-05-01T00:00:00Z"
+            }
+        }`))),
+			expected: &V1{
+				Hostname:    "mlab4.lga0t.measurement-lab.org",
+				IPv4Address: "192.168.0.12",
+				LastBoot:    time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:    "decode-failure",
+			msg:     ioutil.NopCloser(strings.NewReader(`{ THIS IS NOT VALID JSON " },`)),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &WebhookRequest{}
+			err := req.Decode(tt.msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WebhookRequest.Decode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr &&
+				(!tt.expected.LastBoot.Equal(req.V1.LastBoot) ||
+					tt.expected.Hostname != req.V1.Hostname ||
+					tt.expected.IPv4Address != req.V1.IPv4Address ||
+					tt.expected.IPv6Address != req.V1.IPv6Address) {
+				t.Errorf("WebhookRequest.Decode() unexpected values: got %#v, want %#v",
+					req.V1, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds an example implementation of an extension server. The reference implementation decodes the ePoxy WebhookRequest and generates an application-specific response.

This change also modifies the WebhookRequest.Decode interface to work more easily from the extension server, since this is its only use case. As well, this change adds basic unit tests for the `Encode` and `Decode` operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/40)
<!-- Reviewable:end -->
