### PR TITLE
Update extension name for token server

### DIFF
--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -32,7 +32,7 @@ var (
 	// Extensions is a static map of operation names to extension URLS for testing.
 	// TODO: save/retrieve extension configuration in/from datastore.
 	Extensions = map[string]string{
-		"k8stoken": "http://k8s-platform-master.c.mlab-sandbox.internal:8000/v1/operation",
-		"test_op":  "http://soltesz-epoxy-testing-instance-1.c.mlab-sandbox.internal:8001/operation",
+		"allocate_k8s_token": "http://k8s-platform-master.c.mlab-sandbox.internal:8800/allocate_k8s_token",
+		"test_op":            "http://soltesz-epoxy-testing-instance-1.c.mlab-sandbox.internal:8001/operation",
 	}
 )

--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -32,7 +32,7 @@ var (
 	// Extensions is a static map of operation names to extension URLS for testing.
 	// TODO: save/retrieve extension configuration in/from datastore.
 	Extensions = map[string]string{
-		"allocate_k8s_token": "http://k8s-platform-master.c.mlab-sandbox.internal:8800/allocate_k8s_token",
+		"allocate_k8s_token": "http://k8s-platform-master.c.mlab-sandbox.internal:8800/v1/allocate_k8s_token",
 		"test_op":            "http://soltesz-epoxy-testing-instance-1.c.mlab-sandbox.internal:8001/operation",
 	}
 )


### PR DESCRIPTION
This change updates the static extension operation name to match the one defined in https://github.com/m-lab/k8s-support/pull/33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/43)
<!-- Reviewable:end -->
