### PR TITLE
Enforce IP whitelist on Host operations

### DIFF
--- a/cmd/epoxy_boot_server/app.yaml
+++ b/cmd/epoxy_boot_server/app.yaml
@@ -4,3 +4,6 @@ service: boot-api
 
 network:
   name: epoxy-extension-private-network
+
+env_variables:
+  ALLOW_FORWARDED_REQUESTS: 'true'

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -68,6 +68,10 @@ var (
 
 	// bindPort may be set using the PORT environment variable.
 	bindPort = "8080"
+
+	// allowForwardedRequests controls how the ePoxy server evaluates and applies
+	// the Host IP whitelist to incoming requests.
+	allowForwardedRequests = false
 )
 
 // init checks the environment for configuration values.
@@ -78,6 +82,9 @@ func init() {
 	}
 	if port := os.Getenv("PORT"); port != "" {
 		bindPort = port
+	}
+	if allow := os.Getenv("ALLOW_FORWARDED_REQUESTS"); allow == "true" {
+		allowForwardedRequests = true
 	}
 }
 
@@ -159,8 +166,9 @@ func main() {
 		log.Fatalf("Failed to create new datastore client: %s", err)
 	}
 	env := &handler.Env{
-		Config:     storage.NewDatastoreConfig(client),
-		ServerAddr: publicAddr,
+		Config:                 storage.NewDatastoreConfig(client),
+		ServerAddr:             publicAddr,
+		AllowForwardedRequests: allowForwardedRequests,
 	}
 	http.ListenAndServe(addr, newRouter(env))
 }

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -83,7 +83,7 @@ func init() {
 	if port := os.Getenv("PORT"); port != "" {
 		bindPort = port
 	}
-	if allow := os.Getenv("ALLOW_FORWARDED_REQUESTS"); allow == "true" {
+	if os.Getenv("ALLOW_FORWARDED_REQUESTS") == "true" {
 		allowForwardedRequests = true
 	}
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -78,8 +78,9 @@ func (env *Env) requestIsFromHost(req *http.Request, host *storage.Host) error {
 	}
 	log.Println("Header:", req.Header.Get("X-Forwarded-For"), host.IPv4Addr)
 
-	// Check the X-Forwarded-For header.
-	if env.AllowForwardedRequests && (req.Header.Get("X-Forwarded-For") == host.IPv4Addr) {
+	// Split the header into individual IPs. The first IP is the original client.
+	fwdIPs := strings.Split(req.Header.Get("X-Forwarded-For"), ", ")
+	if env.AllowForwardedRequests && len(fwdIPs) > 0 && fwdIPs[0] == host.IPv4Addr {
 		return nil
 	}
 	// RemoteAddr may encode IPv6 addresses, so parse the "host:port" value carefully.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -70,7 +70,7 @@ func (env *Env) requestIsFromHost(req *http.Request, host *storage.Host) error {
 	// forwareded by a load balancer, which adds the `X-Forwarded-For` header.
 	//
 	// Depending on the value of AllowForwardedRequests, we check the X-Forwarded-For
-	// header or the value in RemoteAddr.
+	// header (when true) or the value in RemoteAddr (when false).
 
 	// TODO: allow requests from an administrative network.
 
@@ -84,7 +84,7 @@ func (env *Env) requestIsFromHost(req *http.Request, host *storage.Host) error {
 		return ErrCannotAccessHost
 	}
 	// Check the RemoteAddr host.
-	if !env.AllowForwardedRequests && strings.HasPrefix(remote.Hostname(), host.IPv4Addr) {
+	if !env.AllowForwardedRequests && (remote.Hostname() == host.IPv4Addr) {
 		return nil
 	}
 	return ErrCannotAccessHost

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -73,6 +73,9 @@ func (env *Env) requestIsFromHost(req *http.Request, host *storage.Host) error {
 	// header (when true) or the value in RemoteAddr (when false).
 
 	// TODO: allow requests from an administrative network.
+	for k, v := range req.Header {
+		log.Println("Header:", k, v)
+	}
 
 	// Check the X-Forwarded-For header.
 	if env.AllowForwardedRequests && (req.Header.Get("X-Forwarded-For") == host.IPv4Addr) {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -58,6 +58,14 @@ func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, err.Error(), http.StatusNotFound)
 		return
 	}
+	log.Println(
+		"Host:", host.IPv4Addr,
+		"remote:", req.RemoteAddr,
+		"fowarded-for:", req.Header.Get("X-Forwarded-For"))
+	for k, vals := range req.Header {
+		log.Println("headers:", k, vals)
+	}
+
 	// TODO(soltesz):
 	// * Verify that the source IP maches the host IP.
 	// * Save information sent in PostForm.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -76,6 +76,7 @@ func (env *Env) requestIsFromHost(req *http.Request, host *storage.Host) error {
 	for k, v := range req.Header {
 		log.Println("Header:", k, v)
 	}
+	log.Println("Header:", req.Header.Get("X-Forwarded-For"), host.IPv4Addr)
 
 	// Check the X-Forwarded-For header.
 	if env.AllowForwardedRequests && (req.Header.Get("X-Forwarded-For") == host.IPv4Addr) {


### PR DESCRIPTION
This PR enables strict whitelist enforcement for Host operations.

Previously, any machine could request the stage1 script on behalf of another machine. For test nodes and development for sandbox deployments, this was adequate. As we deploy to additional sites, we must restrict state-changing operations to the host itself.

Ideally, the epoxy server would verify the "remote address" of the connecting server. But, when running in AppEngine, all requests are terminated by a load balancer and forwarded to the ePoxy server. This change includes the option of trusting the `X-Forwarded-For` header added by the AppEngine servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/44)
<!-- Reviewable:end -->
