### PR TITLE
Add prometheus metrics to the epoxy boot server

### DIFF
--- a/cmd/epoxy_boot_server/app.yaml
+++ b/cmd/epoxy_boot_server/app.yaml
@@ -3,7 +3,13 @@ env: flex
 service: boot-api
 
 network:
+  instance_tag: epoxy-boot-api
   name: epoxy-extension-private-network
+  # Forward port 9090 on the GCE instance address to the same port in the
+  # container address. Only forward TCP traffic.
+  # Note: the default AppEngine container port 8080 cannot be forwarded.
+  forwarded_ports:
+    - 9090/tcp
 
 env_variables:
   ALLOW_FORWARDED_REQUESTS: 'true'

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -44,7 +44,10 @@ import (
 	"cloud.google.com/go/datastore"
 	"github.com/gorilla/mux"
 	"github.com/m-lab/epoxy/handler"
+	"github.com/m-lab/epoxy/metrics"
 	"github.com/m-lab/epoxy/storage"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -111,7 +114,8 @@ func newRouter(env *handler.Env) *mux.Router {
 	// Stage1 scripts are always the first script fetched by a booting machine.
 	// "stage1.ipxe" is the target for ROM-based iPXE clients.
 	addRoute(router, "POST", "/v1/boot/{hostname}/stage1.ipxe",
-		http.HandlerFunc(env.GenerateStage1IPXE))
+		promhttp.InstrumentHandlerDuration(metrics.RequestDuration,
+			http.HandlerFunc(env.GenerateStage1IPXE)))
 
 	// TODO(soltesz): add a target for CD-based ePoxy clients.
 	// addRoute(router, "POST", "/v1/boot/{hostname}/stage1.json", generateStage1Json)
@@ -150,6 +154,18 @@ func checkHealth(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprint(rw, "ok")
 }
 
+func setupMetricsHandler(dsCfg *storage.DatastoreConfig) {
+	prometheus.Register(metrics.NewCollector("epoxy_last_boot", dsCfg))
+	prometheus.Register(metrics.NewCollector("epoxy_last_success", dsCfg))
+	// Define a custom serve mux for prometheus to listen on a separate port.
+	// We listen on a separate port so we can forward this port on the host VM.
+	// We cannot forward port 8080 because it is used by AppEngine.
+	mux := http.NewServeMux()
+	// Assign the default prometheus handler to the standard exporter path.
+	mux.Handle("/metrics", promhttp.Handler())
+	log.Fatal(http.ListenAndServe(":9090", mux))
+}
+
 func main() {
 	if projectID == "" {
 		log.Fatalf("Environment variable GCLOUD_PROJECT must specify a project ID for Datastore.")
@@ -165,10 +181,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create new datastore client: %s", err)
 	}
+	dsCfg := storage.NewDatastoreConfig(client)
 	env := &handler.Env{
-		Config:                 storage.NewDatastoreConfig(client),
+		Config:                 dsCfg,
 		ServerAddr:             publicAddr,
 		AllowForwardedRequests: allowForwardedRequests,
 	}
+	go setupMetricsHandler(dsCfg)
 	http.ListenAndServe(addr, newRouter(env))
 }

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -155,6 +155,10 @@ func checkHealth(rw http.ResponseWriter, req *http.Request) {
 }
 
 func setupMetricsHandler(dsCfg *storage.DatastoreConfig) {
+	// Note: we use custom collectors to read directly from datastore rather than
+	// instrumenting http handlers because we want to guarantee that metrics are
+	// always available, even after an appengine server restart. These metrics will
+	// be critical for defining alerts on boot failures.
 	prometheus.Register(metrics.NewCollector("epoxy_last_boot", dsCfg))
 	prometheus.Register(metrics.NewCollector("epoxy_last_success", dsCfg))
 	// Define a custom serve mux for prometheus to listen on a separate port.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/m-lab/epoxy/extension"
+	"github.com/m-lab/epoxy/metrics"
 	"github.com/m-lab/epoxy/storage"
 	"github.com/m-lab/epoxy/template"
 )
@@ -130,6 +131,9 @@ func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) {
 
 	// Generate new session IDs.
 	host.GenerateSessionIDs()
+
+	// Count all requests for the stage1 target.
+	metrics.Stage1Total.WithLabelValues(host.Name).Inc()
 
 	// Save host record to Datastore to commit session IDs.
 	if err := env.Config.Save(host); err != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,106 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// Package metrics contains prometheus metric definitions for the epoxy server.
+package metrics
+
+import (
+	"log"
+
+	"github.com/m-lab/epoxy/storage"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// Stage1Total counts the number of host boots.
+	Stage1Total = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "epoxy_stage1_total",
+			Help: "Total number of boots per machine.",
+		},
+		// Machine name.
+		[]string{"machine"},
+	)
+
+	// RequestDuration profiles request latency.
+	RequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "epoxy_request_duration_seconds",
+			Help: "A histogram of request latencies.",
+			// Note: use default buckets.
+		},
+		[]string{"code"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(Stage1Total)
+	prometheus.MustRegister(RequestDuration)
+}
+
+// Config provides access to Host records.
+type Config interface {
+	List() ([]*storage.Host, error)
+}
+
+// Collector defines a custom collector for reading metrics from datastore.
+type Collector struct {
+	name   string
+	desc   *prometheus.Desc
+	config Config
+}
+
+// NewCollector creates a new datastore collector instance. The metricName should
+// be one of "epoxy_last_boot" or "epoxy_last_success".
+func NewCollector(metricName string, config Config) *Collector {
+	return &Collector{
+		name:   metricName,
+		desc:   nil,
+		config: config,
+	}
+}
+
+// Describe satisfies the prometheus.Collector interface. Describe is called
+// immediately after registering the collector.
+func (col *Collector) Describe(ch chan<- *prometheus.Desc) {
+	if col.desc == nil {
+		col.desc = prometheus.NewDesc(col.name, "The last timestamp for "+col.name, []string{"machine"}, nil)
+	}
+	ch <- col.desc
+}
+
+// Collect satisfies the prometheus.Collector interface. Collect reports values
+// from hosts datastore.
+func (col *Collector) Collect(ch chan<- prometheus.Metric) {
+	hosts, err := col.config.List()
+	if err != nil {
+		log.Println("Failed to list hosts", err)
+		return
+	}
+	for i := range hosts {
+		var ts float64
+		switch col.name {
+		case "epoxy_last_boot":
+			ts = float64(hosts[i].LastSessionCreation.UnixNano()) / 1e9
+		case "epoxy_last_success":
+			ts = float64(hosts[i].LastSuccess.UnixNano()) / 1e9
+		default:
+			log.Println("Unknown collector name:", col.name)
+			return
+		}
+		ch <- prometheus.MustNewConstMetric(
+			col.desc, prometheus.GaugeValue, ts, hosts[i].Name)
+	}
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,94 @@
+// Copyright 2016 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package metrics
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/m-lab/epoxy/storage"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// fakeConfig emulates the storage.Config interface for unit tests.
+type fakeConfig struct {
+	host *storage.Host
+}
+
+// List returns a copy of the fakeConfig host.
+func (f fakeConfig) List() ([]*storage.Host, error) {
+	h := make([]*storage.Host, 1)
+	h[0] = f.host
+	return h, nil
+}
+
+func TestNewCollector(t *testing.T) {
+	tests := []struct {
+		name       string
+		metricName string
+		want       string
+	}{
+		{
+			name:       "success",
+			metricName: "epoxy_last_boot",
+			want:       `epoxy_last_boot{machine="mlab1.foo01"}`,
+		},
+		{
+			name:       "success",
+			metricName: "epoxy_last_success",
+			want:       `epoxy_last_success{machine="mlab1.foo01"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := fakeConfig{
+				host: &storage.Host{
+					Name:                "mlab1.foo01",
+					LastSessionCreation: time.Now(),
+					LastSuccess:         time.Now(),
+				},
+			}
+			prometheus.MustRegister(NewCollector(tt.metricName, cfg))
+			ts := httptest.NewServer(promhttp.Handler())
+			resp, err := http.Get(ts.URL)
+			if err != nil {
+				t.Fatalf("Metrics request failed: %v", err)
+			}
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("Failed to read results: %v", err)
+			}
+			msg := string(b)
+			lines := strings.Split(msg, "\n")
+			success := false
+			for i := range lines {
+				if strings.HasPrefix(lines[i], tt.want) {
+					success = true
+					break
+				}
+			}
+			if !success {
+				t.Fatalf("Failed to find: %v", tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds basic prometheus metrics to the epoxy boot server.

We use the standard AppEngine forwarded port configuration to read metrics on port 9090. Only the prometheus handler listens on port 9090, so there is no risk of side channel operations on epoxy hosts.

To avoid metrics coming and going as the servers running in AppEngine could, the "epoxy_last_boot" and "epoxy_last_success" metric time stamps are read directly from the Host records in datastore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/47)
<!-- Reviewable:end -->
