### PR TITLE
Set Extensions allocate_k8s_token URL based on GCLOUD_PROJECT

### DIFF
--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -14,7 +14,10 @@
 //////////////////////////////////////////////////////////////////////////////
 package storage
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // ExtentionOperation maps an operation name (used in URLs) to an extension service URL.
 type ExtentionOperation struct {
@@ -34,8 +37,8 @@ var (
 	// Extensions is a static map of operation names to extension URLS for testing.
 	// TODO: save/retrieve extension configuration in/from datastore.
 	Extensions = map[string]string{
-		"allocate_k8s_token": "http://k8s-platform-master.c.mlab-sandbox.internal:8800/v1/allocate_k8s_token",
-		"test_op":            "http://soltesz-epoxy-testing-instance-1.c.mlab-sandbox.internal:8001/operation",
+		"allocate_k8s_token": "http://k8s-platform-master.c.%s.internal:8800/v1/allocate_k8s_token",
+		"test_op":            "http://soltesz-epoxy-testing-instance-1.c.%s.internal:8001/operation",
 	}
 )
 
@@ -43,6 +46,8 @@ func init() {
 	// TODO: Remove this logic once the allocate_k8s_token URL is stored/read from datastore.
 	projectID := os.Getenv("GCLOUD_PROJECT")
 	if projectID != "" {
-		Extensions["allocate_k8s_token"] = "http://k8s-platform-master.c." + projectID + ".internal:8800/v1/allocate_k8s_token"
+		for key, value := range Extensions {
+			Extensions[key] = fmt.Sprintf(value, projectID)
+		}
 	}
 }

--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -14,6 +14,8 @@
 //////////////////////////////////////////////////////////////////////////////
 package storage
 
+import "os"
+
 // ExtentionOperation maps an operation name (used in URLs) to an extension service URL.
 type ExtentionOperation struct {
 	// Name is the operation name. This will appear in URLs to the ePoxy server.
@@ -36,3 +38,11 @@ var (
 		"test_op":            "http://soltesz-epoxy-testing-instance-1.c.mlab-sandbox.internal:8001/operation",
 	}
 )
+
+func init() {
+	// TODO: Remove this logic once the allocate_k8s_token URL is stored/read from datastore.
+	projectID := os.Getenv("GCLOUD_PROJECT")
+	if projectID != "" {
+		Extensions["allocate_k8s_token"] = "http://k8s-platform-master.c." + projectID + ".internal:8800/v1/allocate_k8s_token"
+	}
+}


### PR DESCRIPTION
This change updates the `Extensions["allocate_k8s_token"]` URL based on the current value of `GCLOUD_PROJECT`.

This change fixes a bug that prevents the mlab-staging deployment from successfully contacting the token server in the staging k8s platform master.

Ultimately, this logic should be removed once the `Extension` URLs are read from configuration storage in datastore or similar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/48)
<!-- Reviewable:end -->
