### PR TITLE
Changes the DNS name of the token-server to something static.

### DIFF
--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -37,7 +37,7 @@ var (
 	// Extensions is a static map of operation names to extension URLS for testing.
 	// TODO: save/retrieve extension configuration in/from datastore.
 	Extensions = map[string]string{
-		"allocate_k8s_token": "http://k8s-platform-master.c.%s.internal:8800/v1/allocate_k8s_token",
+		"allocate_k8s_token": "http://token-server.%s.measurementlab.net:8800/v1/allocate_k8s_token",
 		"test_op":            "http://soltesz-epoxy-testing-instance-1.c.%s.internal:8001/operation",
 	}
 )


### PR DESCRIPTION
This is not ideal in that we are publishing a public DNS record with a private, internal IP address. However, thus far, I haven't been able to determine any other mechanism to give a DNS name to a private IP address in GCP, short of running our own internal DNS server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/51)
<!-- Reviewable:end -->
