### PR TITLE
Changes the VPC network to k8s-platform-master

### DIFF
--- a/cmd/epoxy_boot_server/app.yaml
+++ b/cmd/epoxy_boot_server/app.yaml
@@ -4,7 +4,7 @@ service: boot-api
 
 network:
   instance_tag: epoxy-boot-api
-  name: epoxy-extension-private-network
+  name: k8s-platform-master
   # Forward port 9090 on the GCE instance address to the same port in the
   # container address. Only forward TCP traffic.
   # Note: the default AppEngine container port 8080 cannot be forwarded.


### PR DESCRIPTION
The old network, epoxy-extension-private-network, had a name that was too specific to one particular service. This change the network name to one that is more generic for the entire k8s-master, ePoxy, etcd environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/53)
<!-- Reviewable:end -->
