### PR TITLE
Changes the VPC network in which ePoxy runs and also assigns it to a custom subnet.

### DIFF
--- a/cmd/epoxy_boot_server/app.yaml
+++ b/cmd/epoxy_boot_server/app.yaml
@@ -4,7 +4,8 @@ service: boot-api
 
 network:
   instance_tag: epoxy-boot-api
-  name: k8s-platform-master
+  name: mlab-platform-network
+  subnetwork_name: epoxy
   # Forward port 9090 on the GCE instance address to the same port in the
   # container address. Only forward TCP traffic.
   # Note: the default AppEngine container port 8080 cannot be forwarded.


### PR DESCRIPTION
The GCP VPC network `mlab-platform-network` is where the k8s platform cluster will run, in the `kubernetes` subnet. ePoxy runs in it's own subnet and only had access to TCP port 8800 in the `kubernetes` subnet (via firewalling) to access the token-server, otherwise it is isolated somewhat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/54)
<!-- Reviewable:end -->
