### PR TITLE
Auto-update: Add support for running epoxy_client in stage1

### DIFF
--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -117,8 +117,9 @@ func newRouter(env *handler.Env) *mux.Router {
 		promhttp.InstrumentHandlerDuration(metrics.RequestDuration,
 			http.HandlerFunc(env.GenerateStage1IPXE)))
 
-	// TODO(soltesz): add a target for CD-based ePoxy clients.
-	// addRoute(router, "POST", "/v1/boot/{hostname}/stage1.json", generateStage1Json)
+	// "stage1.json" is the target for native ePoxy clients.
+	addRoute(router, "POST", "/v1/boot/{hostname}/stage1.json",
+		http.HandlerFunc(env.GenerateStage1JSON))
 
 	// TODO: make the names stage2 and stage3 arbitrary when we need to support
 	// the case where not every machine has the same stage2 or stage3.

--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -21,6 +21,9 @@ var (
 		"Read kernel cmdline parameters from the contents of this file.")
 	flagAction = flag.String("action", "epoxy.stage2",
 		"Execute the config loaded from the URL in this kernel parameter.")
+	flagAddKargs = flag.Bool("extra-kargs", false,
+		"Combine the local kargs with those returned from the action url. "+
+			"Existing kargs are never replaced. Only useful for stage1.")
 	flagReport = flag.String("report", "epoxy.report",
 		"Report success or errors with the URL in this kernel parameter.")
 	flagDryrun = flag.Bool("dryrun", false,
@@ -43,7 +46,7 @@ func main() {
 	c.ParseCmdline(string(b))
 
 	// Run the config loaded from the action URL.
-	err = c.Run(*flagAction, *flagDryrun)
+	err = c.Run(*flagAction, *flagAddKargs, *flagDryrun)
 	if err != nil {
 		// Define a successful result.
 		result = "error: " + err.Error()

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -154,6 +154,8 @@ func (env *Env) GenerateStage1IPXE(rw http.ResponseWriter, req *http.Request) {
 	return
 }
 
+// TODO: consolidate logic in GenerateStage1IPXE & GenerateStage1JSON.
+
 // GenerateStage1JSON creates the stage1 JSON epoxy_client script for booting
 // machines.
 func (env *Env) GenerateStage1JSON(rw http.ResponseWriter, req *http.Request) {

--- a/template/template.go
+++ b/template/template.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
 
 	"github.com/m-lab/epoxy/nextboot"
 	"github.com/m-lab/epoxy/storage"
@@ -40,6 +39,10 @@ set {{ $key }}_url {{ $value }}
 
 chain ${stage1chain_url}
 `
+
+var (
+	stage1Ipxe = template.Must(template.New("stage1").Parse(stage1IpxeTemplate))
+)
 
 // FormatStage1IPXEScript generates a stage1 iPXE boot script using values from Host.
 func FormatStage1IPXEScript(h *storage.Host, serverAddr string) string {
@@ -67,12 +70,9 @@ func FormatStage1IPXEScript(h *storage.Host, serverAddr string) string {
 	}
 	vals["Extensions"] = extensionURLs
 
-	t := template.Must(template.New("stage1").Parse(stage1IpxeTemplate))
-	err := t.Execute(&b, vals)
+	err := stage1Ipxe.Execute(&b, vals)
 	if err != nil {
-		// This error could only occur with a bad template, which should
-		// be caught by unit tests.
-		log.Print(err)
+		// Unit tests should catch this case due to bad template.
 		// Use panic instead of log.Fatal so the server can recover.
 		panic(err)
 		// TODO: return a static fallback configuration via the stage1to2_url.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
-
+	"github.com/lithammer/dedent"
 	"github.com/m-lab/epoxy/storage"
 )
 
@@ -64,5 +64,77 @@ func TestFormatStage1IPXEScript(t *testing.T) {
 	actualLines := strings.Split(script, "\n")
 	if diff := pretty.Compare(expectedLines, actualLines); diff != "" {
 		t.Errorf("Wrong iPXE script: diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestCreateStage1Action(t *testing.T) {
+	tests := []struct {
+		name string
+		h    *storage.Host
+		want string
+	}{
+		{
+			name: "success",
+			h: &storage.Host{
+				Name:       "mlab1.foo01.measurement-lab.org",
+				Extensions: []string{"allocate_k8s_token"},
+				CurrentSessionIDs: storage.SessionIDs{
+					Stage2ID:    "01234",
+					Stage3ID:    "56789",
+					ReportID:    "86420",
+					ExtensionID: "75319",
+				},
+			},
+			want: dedent.Dedent(`
+                {
+                    "kargs": {
+                        "epoxy.allocate_k8s_token": "https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/75319/extension/allocate_k8s_token",
+                        "epoxy.report": "https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/86420/report",
+                        "epoxy.stage2": "https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/01234/stage2",
+                        "epoxy.stage3": "https://boot-api-mlab-sandbox.appspot.com/v1/boot/mlab1.foo01.measurement-lab.org/56789/stage3"
+                    },
+                    "v1": {}
+                }`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CreateStage1Action(tt.h, "boot-api-mlab-sandbox.appspot.com"); got != tt.want[1:] {
+				t.Errorf("CreateStage1Action() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatJSONConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		h     *storage.Host
+		stage string
+		want  string
+	}{
+		{
+			name: "success",
+			h: &storage.Host{
+				Name: "mlab1.foo01.measurement-lab.org",
+				Boot: storage.Sequence{
+					Stage2ChainURL: "https://example.com/path/stage2/stage2",
+				},
+			},
+			stage: "stage2",
+			want: dedent.Dedent(`
+                {
+                    "v1": {
+                        "chain": "https://example.com/path/stage2/stage2"
+                    }
+                }`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatJSONConfig(tt.h, tt.stage); got != tt.want[1:] {
+				t.Errorf("FormatJSONConfig() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This change adds support to the epoxy_boot_server and epoxy_client to run from stage1 in service of auto-updates.

In service of: https://github.com/m-lab/dev-tracker/issues/132

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/56)
<!-- Reviewable:end -->
