### PR TITLE
Add subcommands for create & update operations

### DIFF
--- a/cmd/epoxy_admin/command/create.go
+++ b/cmd/epoxy_admin/command/create.go
@@ -120,20 +120,20 @@ func init() {
 		"Set Host.UpdateEnabled to true for an existing Host.")
 	createCmd.Flags().StringVar(&fBootStage1, "boot-stage1",
 		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage1to2.ipxe",
-		"Absolute URL to an action definition to run during stage1 to boot stage2.")
+		"Absolute URL to an action definition to run during stage1 to stage2 boot.")
 	createCmd.Flags().StringVar(&fBootStage2, "boot-stage2",
 		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage2to3.json",
-		"Absolute URL to an action definition to run during stage2 to boot stage3.")
+		"Absolute URL to an action definition to run during stage2 to stage3 boot.")
 	createCmd.Flags().StringVar(&fBootStage3, "boot-stage3",
 		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage3post.json",
-		"Absolute URL to an action definition to run after booting stage3.")
+		"Absolute URL to an action definition to run after running stage3 boot.")
 	createCmd.Flags().StringVar(&fUpdateStage1, "update-stage1",
 		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage1to2.ipxe",
-		"Absolute URL to an action definition to run during stage1 to boot stage2.")
+		"Absolute URL to an action definition to run during stage1 to stage2 update.")
 	createCmd.Flags().StringVar(&fUpdateStage2, "update-stage2",
 		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage2to3.json",
-		"Absolute URL to an action definition to run during stage2 to boot stage3.")
+		"Absolute URL to an action definition to run during stage2 to stage3 update.")
 	createCmd.Flags().StringVar(&fUpdateStage3, "update-stage3",
 		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage3post.json",
-		"Absolute URL to an action definition to run after booting stage3.")
+		"Absolute URL to an action definition to run after running stage3 update.")
 }

--- a/cmd/epoxy_admin/command/create.go
+++ b/cmd/epoxy_admin/command/create.go
@@ -1,0 +1,138 @@
+// Copyright 2018 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"cloud.google.com/go/datastore"
+
+	"github.com/m-lab/epoxy/storage"
+	"github.com/m-lab/go/rtx"
+
+	"github.com/spf13/cobra"
+)
+
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Adds a new ePoxy Host record to Datastore",
+	Long: `
+USAGE:
+	**ONLY FOR TESTING**
+
+    Creates a new datastore Host record for ePoxy server. Calling "create" on
+    an existing host will overwrite the original.
+	
+EXAMPLE:
+
+    # Use the default boot and update stage URLs:
+    epoxy_admin create --project mlab-sandbox \
+        --hostname mlab3.iad1t.measurement-lab.org \
+        --address 165.117.240.35
+`,
+	Run: runCreate,
+}
+
+// fmtURL formats (if needed) and parses the given string as a URL. If the
+// resulting URL is invalid, fmtURL panics.
+func fmtURL(urlStr string) string {
+	if strings.Contains(urlStr, "%s") {
+		urlStr = fmt.Sprintf(urlStr, fProject)
+	}
+	_, err := url.Parse(urlStr)
+	rtx.Must(err, "Failed to parse URL: %s", urlStr)
+	return urlStr
+}
+
+// TODO: add unit tests by masking out NewClient & NewDatstoreConfig. Consider
+// promoting the fake datastore types from storage/datastore_test.go to an
+// internal fake package.
+func runCreate(cmd *cobra.Command, args []string) {
+	// Setup Datastore client.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := datastore.NewClient(ctx, fProject)
+	rtx.Must(err, "Failed to create new datastore client")
+
+	// Save the host record to Datstore.
+	ds := storage.NewDatastoreConfig(client)
+
+	h := &storage.Host{
+		Name:          fHostname,
+		IPv4Addr:      fAddress,
+		UpdateEnabled: fUpdate,
+		Extensions:    []string{fExtension},
+		Boot: storage.Sequence{
+			Stage1ChainURL: fmtURL(fBootStage1),
+			Stage2ChainURL: fmtURL(fBootStage2),
+			Stage3ChainURL: fmtURL(fBootStage3),
+		},
+		Update: storage.Sequence{
+			Stage1ChainURL: fmtURL(fUpdateStage1),
+			Stage2ChainURL: fmtURL(fUpdateStage2),
+			Stage3ChainURL: fmtURL(fUpdateStage3),
+		},
+	}
+
+	// Save the host record.
+	err = ds.Save(h)
+	rtx.Must(err, "Failed to save new host record")
+
+	// Retrieve the host record from Datastore to exercise the full save & load path.
+	h, err = ds.Load(h.Name)
+	rtx.Must(err, "Failed to save new host record")
+	fmt.Println(h.String())
+}
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+
+	// Required local flags.
+	createCmd.Flags().StringVar(&fHostname, "hostname", "",
+		"Hostname of new record.")
+	createCmd.Flags().StringVar(&fAddress, "address", "",
+		"IP address of hostname.")
+	createCmd.MarkFlagRequired("hostname")
+	createCmd.MarkFlagRequired("address")
+
+	// Local flags which will only apply when "create" is called directly.
+	createCmd.Flags().StringVar(&fExtension, "extension", "allocate_k8s_token",
+		"Name of an extension to enable for host.")
+	createCmd.Flags().BoolVar(&fUpdate, "update", false,
+		"Set Host.UpdateEnabled to true for an existing Host.")
+	createCmd.Flags().StringVar(&fBootStage1, "boot-stage1",
+		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage1to2.ipxe",
+		"Absolute URL to an action definition to run during stage1 to boot stage2.")
+	createCmd.Flags().StringVar(&fBootStage2, "boot-stage2",
+		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage2to3.json",
+		"Absolute URL to an action definition to run during stage2 to boot stage3.")
+	createCmd.Flags().StringVar(&fBootStage3, "boot-stage3",
+		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage3post.json",
+		"Absolute URL to an action definition to run after booting stage3.")
+	createCmd.Flags().StringVar(&fUpdateStage1, "update-stage1",
+		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage1to2.ipxe",
+		"Absolute URL to an action definition to run during stage1 to boot stage2.")
+	createCmd.Flags().StringVar(&fUpdateStage2, "update-stage2",
+		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage2to3.json",
+		"Absolute URL to an action definition to run during stage2 to boot stage3.")
+	createCmd.Flags().StringVar(&fUpdateStage3, "update-stage3",
+		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage3post.json",
+		"Absolute URL to an action definition to run after booting stage3.")
+}

--- a/cmd/epoxy_admin/command/create.go
+++ b/cmd/epoxy_admin/command/create.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/datastore"
 
@@ -65,7 +66,7 @@ func fmtURL(urlStr string) string {
 // internal fake package.
 func runCreate(cmd *cobra.Command, args []string) {
 	// Setup Datastore client.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	client, err := datastore.NewClient(ctx, fProject)

--- a/cmd/epoxy_admin/command/delete.go
+++ b/cmd/epoxy_admin/command/delete.go
@@ -12,10 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package command
 
-import "github.com/m-lab/epoxy/cmd/epoxy_admin/command"
+import (
+	"fmt"
 
-func main() {
-	command.Execute()
+	"github.com/spf13/cobra"
+)
+
+// deleteCmd represents the delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Deletes an ePoxy Host record from Datastore",
+	Long: `
+USAGE:
+
+    TODO: implement delete.
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("TODO: implement delete")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/epoxy_admin/command/list.go
+++ b/cmd/epoxy_admin/command/list.go
@@ -12,10 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package command
 
-import "github.com/m-lab/epoxy/cmd/epoxy_admin/command"
+import (
+	"fmt"
 
-func main() {
-	command.Execute()
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists ePoxy Host records from Datastore",
+	Long: `
+USAGE:
+
+    TODO: implement list.
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("TODO: implement list")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/epoxy_admin/command/root.go
+++ b/cmd/epoxy_admin/command/root.go
@@ -1,0 +1,69 @@
+// Copyright 2018 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Flag variables available to all subcommands.
+var (
+	fProject string
+)
+
+// Flag variables used only by the create & update commands. Since only one
+// command is ever run at a time, it is safe to use them for both cases.
+var (
+	fHostname     string
+	fAddress      string
+	fExtension    string
+	fUpdate       bool
+	fBootStage1   string
+	fBootStage2   string
+	fBootStage3   string
+	fUpdateStage1 string
+	fUpdateStage2 string
+	fUpdateStage3 string
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "epoxy_admin",
+	Short: "Administer Datastore for ePoxy Server",
+	Long: `
+USAGE:
+
+  epoxy_admin is a minimal client for adding ePoxy Host records to Datastore
+  for testing. This command is ONLY for testing. Host record management by
+  direct access to Datastore should not be supported.
+`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Persistent flags, which will be global for all subcommands.
+	rootCmd.PersistentFlags().StringVar(&fProject, "project", "mlab-sandbox", "GCP project ID.")
+}

--- a/cmd/epoxy_admin/command/update.go
+++ b/cmd/epoxy_admin/command/update.go
@@ -17,6 +17,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/datastore"
 	"github.com/m-lab/epoxy/storage"
@@ -57,7 +58,7 @@ func updateURL(url, original string) string {
 // internal fake package.
 func runUpdate(cmd *cobra.Command, args []string) {
 	// Setup Datastore client.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	client, err := datastore.NewClient(ctx, fProject)

--- a/cmd/epoxy_admin/command/update.go
+++ b/cmd/epoxy_admin/command/update.go
@@ -1,0 +1,124 @@
+// Copyright 2018 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/datastore"
+	"github.com/m-lab/epoxy/storage"
+	"github.com/m-lab/go/rtx"
+	"github.com/spf13/cobra"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Updates an existing ePoxy Host record in Datastore",
+	Long: `
+USAGE:
+	**ONLY FOR TESTING**
+
+    Updates an existing Host record with the given values. Updating a
+    non-existant host is a failure.
+
+EXAMPLE:
+
+    # Set the "update enabled" flag on the Host record.
+    epoxy_admin update --project mlab-sandbox \
+		--hostname mlab3.iad1t.measurement-lab.org \
+		--update
+`,
+	Run: runUpdate,
+}
+
+func updateURL(url, original string) string {
+	if url != "" {
+		return fmtURL(url)
+	}
+	return original
+}
+
+// TODO: add unit tests by masking out NewClient & NewDatstoreConfig. Consider
+// promoting the fake datastore types from storage/datastore_test.go to an
+// internal fake package.
+func runUpdate(cmd *cobra.Command, args []string) {
+	// Setup Datastore client.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := datastore.NewClient(ctx, fProject)
+	rtx.Must(err, "Failed to create new datastore client")
+
+	// Save the host record to Datstore.
+	ds := storage.NewDatastoreConfig(client)
+
+	h, err := ds.Load(fHostname)
+	rtx.Must(err, "Failed to load record for %q", fHostname)
+	h.UpdateEnabled = fUpdate
+	// TODO: support multiple extensions.
+	if fExtension != "" {
+		h.Extensions = []string{fExtension}
+	}
+	if fAddress != "" {
+		h.IPv4Addr = fAddress
+	}
+	h.Boot.Stage1ChainURL = updateURL(fmtURL(fBootStage1), h.Boot.Stage1ChainURL)
+	h.Boot.Stage2ChainURL = updateURL(fmtURL(fBootStage2), h.Boot.Stage2ChainURL)
+	h.Boot.Stage3ChainURL = updateURL(fmtURL(fBootStage3), h.Boot.Stage3ChainURL)
+	h.Update.Stage1ChainURL = updateURL(fmtURL(fUpdateStage1), h.Update.Stage1ChainURL)
+	h.Update.Stage2ChainURL = updateURL(fmtURL(fUpdateStage2), h.Update.Stage2ChainURL)
+	h.Update.Stage3ChainURL = updateURL(fmtURL(fUpdateStage3), h.Update.Stage3ChainURL)
+
+	// Save the host record.
+	err = ds.Save(h)
+	rtx.Must(err, "Failed to save new host record")
+
+	// Retrieve the host record from Datastore to exercise the full save & load path.
+	h, err = ds.Load(h.Name)
+	rtx.Must(err, "Failed to save new host record")
+	fmt.Println(h.String())
+	return
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+
+	// Required local flags.
+	updateCmd.Flags().StringVar(&fHostname, "hostname", "",
+		"Hostname of new record.")
+	updateCmd.MarkFlagRequired("hostname")
+
+	// Local flags which will only run when "update" is called directly.
+	updateCmd.Flags().StringVar(&fAddress, "address", "",
+		"IP address of hostname.")
+	updateCmd.Flags().StringVar(&fExtension, "extension", "",
+		"Name of an extension to enable for host.")
+	updateCmd.Flags().BoolVar(&fUpdate, "update", false,
+		"Set Host.UpdateEnabled to true for an existing Host.")
+	updateCmd.Flags().StringVar(&fBootStage1, "boot-stage1", "",
+		"Absolute URL to an action definition to run during stage1 to boot stage2.")
+	updateCmd.Flags().StringVar(&fBootStage2, "boot-stage2", "",
+		"Absolute URL to an action definition to run during stage2 to boot stage3.")
+	updateCmd.Flags().StringVar(&fBootStage3, "boot-stage3", "",
+		"Absolute URL to an action definition to run after booting stage3.")
+	updateCmd.Flags().StringVar(&fUpdateStage1, "update-stage1", "",
+		"Absolute URL to an action definition to run during stage1 to boot stage2.")
+	updateCmd.Flags().StringVar(&fUpdateStage2, "update-stage2", "",
+		"Absolute URL to an action definition to run during stage2 to boot stage3.")
+	updateCmd.Flags().StringVar(&fUpdateStage3, "update-stage3", "",
+		"Absolute URL to an action definition to run after booting stage3.")
+}

--- a/cmd/epoxy_admin/command/update.go
+++ b/cmd/epoxy_admin/command/update.go
@@ -111,15 +111,15 @@ func init() {
 	updateCmd.Flags().BoolVar(&fUpdate, "update", false,
 		"Set Host.UpdateEnabled to true for an existing Host.")
 	updateCmd.Flags().StringVar(&fBootStage1, "boot-stage1", "",
-		"Absolute URL to an action definition to run during stage1 to boot stage2.")
+		"Absolute URL to an action definition to run during stage1 to stage2 boot.")
 	updateCmd.Flags().StringVar(&fBootStage2, "boot-stage2", "",
-		"Absolute URL to an action definition to run during stage2 to boot stage3.")
+		"Absolute URL to an action definition to run during stage2 to stage3 boot.")
 	updateCmd.Flags().StringVar(&fBootStage3, "boot-stage3", "",
-		"Absolute URL to an action definition to run after booting stage3.")
+		"Absolute URL to an action definition to run after running stage3 boot.")
 	updateCmd.Flags().StringVar(&fUpdateStage1, "update-stage1", "",
-		"Absolute URL to an action definition to run during stage1 to boot stage2.")
+		"Absolute URL to an action definition to run during stage1 to stage2 update.")
 	updateCmd.Flags().StringVar(&fUpdateStage2, "update-stage2", "",
-		"Absolute URL to an action definition to run during stage2 to boot stage3.")
+		"Absolute URL to an action definition to run during stage2 to stage3 update.")
 	updateCmd.Flags().StringVar(&fUpdateStage3, "update-stage3", "",
-		"Absolute URL to an action definition to run after booting stage3.")
+		"Absolute URL to an action definition to run after running stage3 update.")
 }


### PR DESCRIPTION
This change uses the [cobra](https://github.com/spf13/cobra) package (a CLI application generator used by kubernetes, docker, and others) to create specific subcommands for `epoxy_admin` to "create" or "update" an ePoxy host record in Datastore.

This functionality is needed to complete the configuration of all mlab4 machines.

This change also includes stubs for future "list" and "delete" operations.

The original epoxy_admin did not include unit tests. The new frame work affords better unit testing of the Run function of each subcommand. Additional restructuring of the fakes in storage/datstore_test.go should make this possible but could make this PR size too large.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/63)
<!-- Reviewable:end -->
