### PR TITLE
Add support for multiple updates

### DIFF
--- a/cmd/epoxy_admin/command/create.go
+++ b/cmd/epoxy_admin/command/create.go
@@ -76,19 +76,19 @@ func runCreate(cmd *cobra.Command, args []string) {
 	ds := storage.NewDatastoreConfig(client)
 
 	h := &storage.Host{
-		Name:          fHostname,
-		IPv4Addr:      fAddress,
-		UpdateEnabled: fUpdate,
-		Extensions:    []string{fExtension},
+		Name:          cfHostname,
+		IPv4Addr:      cfAddress,
+		UpdateEnabled: cfUpdate,
+		Extensions:    []string{cfExtension},
 		Boot: storage.Sequence{
-			Stage1ChainURL: fmtURL(fBootStage1),
-			Stage2ChainURL: fmtURL(fBootStage2),
-			Stage3ChainURL: fmtURL(fBootStage3),
+			Stage1ChainURL: fmtURL(cfBootStage1),
+			Stage2ChainURL: fmtURL(cfBootStage2),
+			Stage3ChainURL: fmtURL(cfBootStage3),
 		},
 		Update: storage.Sequence{
-			Stage1ChainURL: fmtURL(fUpdateStage1),
-			Stage2ChainURL: fmtURL(fUpdateStage2),
-			Stage3ChainURL: fmtURL(fUpdateStage3),
+			Stage1ChainURL: fmtURL(cfUpdateStage1),
+			Stage2ChainURL: fmtURL(cfUpdateStage2),
+			Stage3ChainURL: fmtURL(cfUpdateStage3),
 		},
 	}
 
@@ -106,34 +106,34 @@ func init() {
 	rootCmd.AddCommand(createCmd)
 
 	// Required local flags.
-	createCmd.Flags().StringVar(&fHostname, "hostname", "",
+	createCmd.Flags().StringVar(&cfHostname, "hostname", "",
 		"Hostname of new record.")
-	createCmd.Flags().StringVar(&fAddress, "address", "",
+	createCmd.Flags().StringVar(&cfAddress, "address", "",
 		"IP address of hostname.")
 	createCmd.MarkFlagRequired("hostname")
 	createCmd.MarkFlagRequired("address")
 
 	// Local flags which will only apply when "create" is called directly.
-	createCmd.Flags().StringVar(&fExtension, "extension", "allocate_k8s_token",
+	createCmd.Flags().StringVar(&cfExtension, "extension", "allocate_k8s_token",
 		"Name of an extension to enable for host.")
-	createCmd.Flags().BoolVar(&fUpdate, "update", false,
+	createCmd.Flags().BoolVar(&cfUpdate, "update", false,
 		"Set Host.UpdateEnabled to true for an existing Host.")
-	createCmd.Flags().StringVar(&fBootStage1, "boot-stage1",
+	createCmd.Flags().StringVar(&cfBootStage1, "boot-stage1",
 		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage1to2.ipxe",
 		"Absolute URL to an action definition to run during stage1 to stage2 boot.")
-	createCmd.Flags().StringVar(&fBootStage2, "boot-stage2",
+	createCmd.Flags().StringVar(&cfBootStage2, "boot-stage2",
 		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage2to3.json",
 		"Absolute URL to an action definition to run during stage2 to stage3 boot.")
-	createCmd.Flags().StringVar(&fBootStage3, "boot-stage3",
+	createCmd.Flags().StringVar(&cfBootStage3, "boot-stage3",
 		"https://storage.googleapis.com/epoxy-%s/stage3_coreos/stage3post.json",
 		"Absolute URL to an action definition to run after running stage3 boot.")
-	createCmd.Flags().StringVar(&fUpdateStage1, "update-stage1",
+	createCmd.Flags().StringVar(&cfUpdateStage1, "update-stage1",
 		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage1to2.ipxe",
 		"Absolute URL to an action definition to run during stage1 to stage2 update.")
-	createCmd.Flags().StringVar(&fUpdateStage2, "update-stage2",
+	createCmd.Flags().StringVar(&cfUpdateStage2, "update-stage2",
 		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage2to3.json",
 		"Absolute URL to an action definition to run during stage2 to stage3 update.")
-	createCmd.Flags().StringVar(&fUpdateStage3, "update-stage3",
+	createCmd.Flags().StringVar(&cfUpdateStage3, "update-stage3",
 		"https://storage.googleapis.com/epoxy-%s/stage3_mlxupdate/stage3post.json",
 		"Absolute URL to an action definition to run after running stage3 update.")
 }

--- a/cmd/epoxy_admin/command/root.go
+++ b/cmd/epoxy_admin/command/root.go
@@ -26,19 +26,33 @@ var (
 	fProject string
 )
 
-// Flag variables used only by the create & update commands. Since only one
-// command is ever run at a time, it is safe to use them for both cases.
+// Flag variables used only by the create & update commands. Since flags and
+// their default values are defined in init(), we need separate variables for
+// different default values.
 var (
-	fHostname     string
-	fAddress      string
-	fExtension    string
-	fUpdate       bool
-	fBootStage1   string
-	fBootStage2   string
-	fBootStage3   string
-	fUpdateStage1 string
-	fUpdateStage2 string
-	fUpdateStage3 string
+	// Create flags.
+	cfHostname     string
+	cfAddress      string
+	cfExtension    string
+	cfUpdate       bool
+	cfBootStage1   string
+	cfBootStage2   string
+	cfBootStage3   string
+	cfUpdateStage1 string
+	cfUpdateStage2 string
+	cfUpdateStage3 string
+
+	// Update flags.
+	ufHostname     string
+	ufAddress      string
+	ufExtension    string
+	ufUpdate       bool
+	ufBootStage1   string
+	ufBootStage2   string
+	ufBootStage3   string
+	ufUpdateStage1 string
+	ufUpdateStage2 string
+	ufUpdateStage3 string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/epoxy_admin/command/update.go
+++ b/cmd/epoxy_admin/command/update.go
@@ -67,22 +67,22 @@ func runUpdate(cmd *cobra.Command, args []string) {
 	// Save the host record to Datstore.
 	ds := storage.NewDatastoreConfig(client)
 
-	h, err := ds.Load(fHostname)
-	rtx.Must(err, "Failed to load record for %q", fHostname)
-	h.UpdateEnabled = fUpdate
+	h, err := ds.Load(ufHostname)
+	rtx.Must(err, "Failed to load record for %q", ufHostname)
+	h.UpdateEnabled = ufUpdate
 	// TODO: support multiple extensions.
-	if fExtension != "" {
-		h.Extensions = []string{fExtension}
+	if ufExtension != "" {
+		h.Extensions = []string{ufExtension}
 	}
-	if fAddress != "" {
-		h.IPv4Addr = fAddress
+	if ufAddress != "" {
+		h.IPv4Addr = ufAddress
 	}
-	h.Boot.Stage1ChainURL = updateURL(fmtURL(fBootStage1), h.Boot.Stage1ChainURL)
-	h.Boot.Stage2ChainURL = updateURL(fmtURL(fBootStage2), h.Boot.Stage2ChainURL)
-	h.Boot.Stage3ChainURL = updateURL(fmtURL(fBootStage3), h.Boot.Stage3ChainURL)
-	h.Update.Stage1ChainURL = updateURL(fmtURL(fUpdateStage1), h.Update.Stage1ChainURL)
-	h.Update.Stage2ChainURL = updateURL(fmtURL(fUpdateStage2), h.Update.Stage2ChainURL)
-	h.Update.Stage3ChainURL = updateURL(fmtURL(fUpdateStage3), h.Update.Stage3ChainURL)
+	h.Boot.Stage1ChainURL = updateURL(fmtURL(ufBootStage1), h.Boot.Stage1ChainURL)
+	h.Boot.Stage2ChainURL = updateURL(fmtURL(ufBootStage2), h.Boot.Stage2ChainURL)
+	h.Boot.Stage3ChainURL = updateURL(fmtURL(ufBootStage3), h.Boot.Stage3ChainURL)
+	h.Update.Stage1ChainURL = updateURL(fmtURL(ufUpdateStage1), h.Update.Stage1ChainURL)
+	h.Update.Stage2ChainURL = updateURL(fmtURL(ufUpdateStage2), h.Update.Stage2ChainURL)
+	h.Update.Stage3ChainURL = updateURL(fmtURL(ufUpdateStage3), h.Update.Stage3ChainURL)
 
 	// Save the host record.
 	err = ds.Save(h)
@@ -99,27 +99,27 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 
 	// Required local flags.
-	updateCmd.Flags().StringVar(&fHostname, "hostname", "",
+	updateCmd.Flags().StringVar(&ufHostname, "hostname", "",
 		"Hostname of new record.")
 	updateCmd.MarkFlagRequired("hostname")
 
 	// Local flags which will only run when "update" is called directly.
-	updateCmd.Flags().StringVar(&fAddress, "address", "",
+	updateCmd.Flags().StringVar(&ufAddress, "address", "",
 		"IP address of hostname.")
-	updateCmd.Flags().StringVar(&fExtension, "extension", "",
+	updateCmd.Flags().StringVar(&ufExtension, "extension", "",
 		"Name of an extension to enable for host.")
-	updateCmd.Flags().BoolVar(&fUpdate, "update", false,
+	updateCmd.Flags().BoolVar(&ufUpdate, "update", false,
 		"Set Host.UpdateEnabled to true for an existing Host.")
-	updateCmd.Flags().StringVar(&fBootStage1, "boot-stage1", "",
+	updateCmd.Flags().StringVar(&ufBootStage1, "boot-stage1", "",
 		"Absolute URL to an action definition to run during stage1 to stage2 boot.")
-	updateCmd.Flags().StringVar(&fBootStage2, "boot-stage2", "",
+	updateCmd.Flags().StringVar(&ufBootStage2, "boot-stage2", "",
 		"Absolute URL to an action definition to run during stage2 to stage3 boot.")
-	updateCmd.Flags().StringVar(&fBootStage3, "boot-stage3", "",
+	updateCmd.Flags().StringVar(&ufBootStage3, "boot-stage3", "",
 		"Absolute URL to an action definition to run after running stage3 boot.")
-	updateCmd.Flags().StringVar(&fUpdateStage1, "update-stage1", "",
+	updateCmd.Flags().StringVar(&ufUpdateStage1, "update-stage1", "",
 		"Absolute URL to an action definition to run during stage1 to stage2 update.")
-	updateCmd.Flags().StringVar(&fUpdateStage2, "update-stage2", "",
+	updateCmd.Flags().StringVar(&ufUpdateStage2, "update-stage2", "",
 		"Absolute URL to an action definition to run during stage2 to stage3 update.")
-	updateCmd.Flags().StringVar(&fUpdateStage3, "update-stage3", "",
+	updateCmd.Flags().StringVar(&ufUpdateStage3, "update-stage3", "",
 		"Absolute URL to an action definition to run after running stage3 update.")
 }

--- a/cmd/epoxy_admin/command/update.go
+++ b/cmd/epoxy_admin/command/update.go
@@ -75,8 +75,12 @@ func runUpdate(cmd *cobra.Command, args []string) {
 	hosts, err := ds.List()
 	rtx.Must(err, "Failed to list host records")
 
+	// Compile given regex.
+	r, err := regexp.Compile(ufHostname)
+	rtx.Must(err, "Failed to compile given hostname pattern: %q", ufHostname)
+
 	for _, h := range hosts {
-		if matched, err := regexp.MatchString(ufHostname, h.Name); err != nil || !matched {
+		if !r.MatchString(h.Name) {
 			continue
 		}
 		log.Printf("Updating: %s", h.Name)


### PR DESCRIPTION
This change fixes a bug with shared flag variable names and adds the ability to update multiple Host records at once by using --hostname as a regular expression to match the Host FQDN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/64)
<!-- Reviewable:end -->
