### PR TITLE
Skip metrics for registered hosts that have never booted

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -91,6 +91,10 @@ func (col *Collector) Collect(ch chan<- prometheus.Metric) {
 	}
 	for i := range hosts {
 		var ts float64
+		if hosts[i].LastSessionCreation.IsZero() || hosts[i].LastSuccess.IsZero() {
+			// Skip reporting metrics for hosts that have never booted.
+			continue
+		}
 		switch col.name {
 		case "epoxy_last_boot":
 			ts = float64(hosts[i].LastSessionCreation.UnixNano()) / 1e9


### PR DESCRIPTION
This change prevents the creation of metrics for last-boot or last-success if the host has never booted.

With this change we can more easily use the metrics to make rebot "update-aware".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/65)
<!-- Reviewable:end -->
