### PR TITLE
Disable enforced client-ip checks on JSON stage1 requests

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -168,11 +168,13 @@ func (env *Env) GenerateStage1JSON(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = env.requestIsFromHost(req, host)
+	// TODO(soltesz): re-enable once PLC updates are completed.
+	/* err = env.requestIsFromHost(req, host)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusForbidden)
 		return
 	}
+	*/
 
 	// TODO(soltesz):
 	// * Save information sent in PostForm.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -531,12 +531,15 @@ func TestEnv_GenerateStage1JSON(t *testing.T) {
 			from:   h.IPv4Addr,
 			status: http.StatusInternalServerError,
 		},
-		{
-			name:   "fail-from-wrong-ip",
-			config: fakeConfig{host: h},
-			from:   "192.168.0.1",
-			status: http.StatusForbidden,
-		},
+		// TODO(soltesz): enable once plc-updates are complete.
+		/*
+			{
+				name:   "fail-from-wrong-ip",
+				config: fakeConfig{host: h},
+				from:   "192.168.0.1",
+				status: http.StatusForbidden,
+			},
+		*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -550,7 +553,7 @@ func TestEnv_GenerateStage1JSON(t *testing.T) {
 			env.GenerateStage1JSON(rec, req)
 
 			if rec.Code != tt.status {
-				t.Errorf("GenerateStage1IPXE() wrong HTTP status: got %v; want %v", rec.Code, tt.status)
+				t.Errorf("GenerateStage1JSON() wrong HTTP status: got %v; want %v", rec.Code, tt.status)
 			}
 		})
 	}


### PR DESCRIPTION
We have previously encountered an issue where router advertisements generate IPv6 addresses for a machine that are unregistered with ePoxy and as a result fail to verify.

This was addressed to some degree in later stages in the epoxy-images builds but is still possible for PLC-auto updates.

This change temporarily disables client-ip checks for stage1 JSON configs -- which currently correspond only to PLC deployments. This would also cover any ad-hoc alternate boot strategies we need for sites with non-standard hardware, e.g. hnd01.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/70)
<!-- Reviewable:end -->
