### PR TITLE
Add better support for unit testing from other packages

### DIFF
--- a/storage/datastore.go
+++ b/storage/datastore.go
@@ -33,7 +33,7 @@ type DatastoreConfig struct {
 }
 
 // NewDatastoreConfig creates a new DatastoreConfig instance from a *datastore.Client.
-func NewDatastoreConfig(client *datastore.Client) *DatastoreConfig {
+func NewDatastoreConfig(client iface.DatastoreClient) *DatastoreConfig {
 	return &DatastoreConfig{client}
 }
 

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -87,7 +87,7 @@ func TestNewDatastoreClient(t *testing.T) {
 	f := &fakeDatastoreClient{&h}
 	c := NewDatastoreConfig(f)
 
-	h2, err := c.Load("malb1.iad1t.measurement-lab.org")
+	h2, err := c.Load("mlab1.iad1t.measurement-lab.org")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -80,6 +80,22 @@ func (f *errDatastoreClient) GetAll(ctx context.Context, q *datastore.Query, dst
 	return nil, f.err
 }
 
+func TestNewDatastoreClient(t *testing.T) {
+	h := Host{
+		Name: "mlab1.iad1t.measurement-lab.org",
+	}
+	f := &fakeDatastoreClient{&h}
+	c := NewDatastoreConfig(f)
+
+	h2, err := c.Load("malb1.iad1t.measurement-lab.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Name != h2.Name {
+		t.Errorf("Load for NewDatastoreConfig failed; want %q, got %q", h.Name, h2.Name)
+	}
+}
+
 func TestDatastore(t *testing.T) {
 	// NB: we store a partial Host record for brevity.
 	h := Host{

--- a/storage/iface/iface.go
+++ b/storage/iface/iface.go
@@ -1,0 +1,16 @@
+package iface
+
+import (
+	"context"
+
+	"cloud.google.com/go/datastore"
+)
+
+// DatastoreClient is an interface to make testing possible. The default
+// implementation is the actual *datastore.Client as returned by
+// datastore.NewClient.
+type DatastoreClient interface {
+	Get(ctx context.Context, key *datastore.Key, dst interface{}) error
+	Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error)
+	GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error)
+}


### PR DESCRIPTION
This PR adds an `iface` subdirectory to the storage package the declare a public interface for the `iface.DatastoreClient`. By making this interface public we can improve the unit tests for other packages that build on the `DatastoreConfig`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/73)
<!-- Reviewable:end -->
