### PR TITLE
Add support for LetsEncrypt and private CA certificates

### DIFF
--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -41,32 +41,36 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/m-lab/go/httpx"
+
 	"cloud.google.com/go/datastore"
 	"github.com/gorilla/mux"
 	"github.com/m-lab/epoxy/handler"
 	"github.com/m-lab/epoxy/metrics"
 	"github.com/m-lab/epoxy/storage"
+	"github.com/m-lab/go/rtx"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/crypto/acme/autocert"
 )
 
 var (
 	// Environment variables are preferred to flags for deployments in
-	// AppEngine. And, using environment variables is encouraged for
-	// twelve-factor apps -- https://12factor.net/config
+	// AppEngine and Docker containers. Using environment variables is encouraged
+	// for twelve-factor apps -- https://12factor.net/config
 
 	// projectID must be set using the GCLOUD_PROJECT environment variable.
 	projectID = os.Getenv("GCLOUD_PROJECT")
 
-	// publicAddr must be set if *not* running in AppEngine. When running in
-	// AppEngine publicAddr is set automatically from a combination of
+	// publicHostname must be set if *not* running in AppEngine. When running in
+	// AppEngine publicHostname is set automatically from a combination of
 	// GCLOUD_PROJECT and GAE_SERVICE environment variables. When not running in
-	// AppEngine, or to override the default in AppEngine, the PUBLIC_ADDRESS
+	// AppEngine, or to override the default in AppEngine, the PUBLIC_HOSTNAME
 	// environment variable must be set instead.
-	publicAddr = os.Getenv("PUBLIC_ADDRESS")
+	publicHostname = os.Getenv("PUBLIC_HOSTNAME")
 
-	// bindAddress may be set using the LISTEN environment variable. By default, ePoxy
-	// listens on all available interfaces.
+	// bindAddress may be set using the LISTEN environment variable. By default,
+	// ePoxy listens on all available interfaces.
 	bindAddress = os.Getenv("LISTEN")
 
 	// bindPort may be set using the PORT environment variable.
@@ -74,14 +78,26 @@ var (
 
 	// allowForwardedRequests controls how the ePoxy server evaluates and applies
 	// the Host IP whitelist to incoming requests.
+	// DEPRECATED.
 	allowForwardedRequests = false
+
+	// serverCert and serverKey are the filenames for the iPXE server certificate.
+	serverCert = os.Getenv("IPXE_CERT_FILE")
+	serverKey  = os.Getenv("IPXE_KEY_FILE")
+
+	// enableLetsEncrypt enables allocation of let's encrypt certs. Should be
+	// disabled for testing.
+	enableLetsEncrypt = os.Getenv("ENABLE_LETSENCRYPT")
+
+	// Create a unified context and a cancel method for main().
+	ctx, cancelCtx = context.WithCancel(context.Background())
 )
 
 // init checks the environment for configuration values.
 func init() {
-	// Only use the automatic public address if PUBLIC_ADDRESS is not already set.
-	if service := os.Getenv("GAE_SERVICE"); service != "" && projectID != "" && publicAddr == "" {
-		publicAddr = fmt.Sprintf("%s-dot-%s.appspot.com", service, projectID)
+	// Only use the automatic public address if PUBLIC_HOSTNAME is not already set.
+	if service := os.Getenv("GAE_SERVICE"); service != "" && projectID != "" && publicHostname == "" {
+		publicHostname = fmt.Sprintf("%s-dot-%s.appspot.com", service, projectID)
 	}
 	if port := os.Getenv("PORT"); port != "" {
 		bindPort = port
@@ -155,7 +171,7 @@ func checkHealth(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprint(rw, "ok")
 }
 
-func setupMetricsHandler(dsCfg *storage.DatastoreConfig) {
+func setupMetricsHandler(dsCfg *storage.DatastoreConfig) *http.ServeMux {
 	// Note: we use custom collectors to read directly from datastore rather than
 	// instrumenting http handlers because we want to guarantee that metrics are
 	// always available, even after an appengine server restart. These metrics will
@@ -168,30 +184,89 @@ func setupMetricsHandler(dsCfg *storage.DatastoreConfig) {
 	mux := http.NewServeMux()
 	// Assign the default prometheus handler to the standard exporter path.
 	mux.Handle("/metrics", promhttp.Handler())
-	log.Fatal(http.ListenAndServe(":9090", mux))
+	return mux
+}
+
+func setupPXEServer(addr string, r *mux.Router) *http.Server {
+	return &http.Server{
+		Addr:    addr,
+		Handler: r,
+	}
+}
+
+func setupLetsEncryptServer(addr string, r *mux.Router, hostname string) *http.Server {
+	// We will listen on standard TLS port using LetsEncrypt certificates.
+	m := &autocert.Manager{
+		// Certificates are cached to a local directory.
+		Cache: autocert.DirCache("autocert.cache"),
+		// The "Let's Encrypt Terms of Service" are accepted automatically.
+		Prompt: autocert.AcceptTOS,
+		// The ePoxy server will only accept TLS host requests from given hostname.
+		HostPolicy: autocert.HostWhitelist(hostname),
+	}
+	// Server with custom TLS config.
+	return &http.Server{
+		Addr:      addr,
+		Handler:   r,
+		TLSConfig: m.TLSConfig(),
+	}
+}
+
+func startAppEngineServerAsync(addr string, router *mux.Router) {
+	ipxeServer := setupPXEServer(addr, router)
+	httpx.ListenAndServeAsync(ipxeServer)
+}
+
+func startTLSServerAsync(addr string, router *mux.Router, hostname string) {
+	tlsServer := setupLetsEncryptServer(addr, router, hostname)
+	// Certificates are already configured in the server.TLSConfig.
+	httpx.ListenAndServeTLSAsync(tlsServer, "", "")
+
+	// Because we're running LetsEncrypt certificates on the standard TLS port,
+	// run the iPXE server on a higher port.
+	ipxeServer := setupPXEServer(addr+"0", router)
+	if serverCert == "" || serverKey == "" {
+		log.Fatalln("WARNING: IPXE_CERT_FILE and IPXE_KEY_FILE were not specified.")
+	}
+	httpx.ListenAndServeTLSAsync(ipxeServer, serverCert, serverKey)
 }
 
 func main() {
+	defer cancelCtx()
+
 	if projectID == "" {
 		log.Fatalf("Environment variable GCLOUD_PROJECT must specify a project ID for Datastore.")
 	}
-	if publicAddr == "" {
-		log.Fatalf("Environment variable PUBLIC_ADDRESS must specify a public service name.")
+	if publicHostname == "" {
+		log.Fatalf("Environment variable PUBLIC_HOSTNAME must specify a public service name.")
 	}
 
-	// TODO(soltesz): support TLS natively for stand-alone mode. Though, this is not necessary for AppEngine.
-	addr := fmt.Sprintf("%s:%s", bindAddress, bindPort)
-	ctx := context.Background()
+	tlsAddr := fmt.Sprintf("%s:%s", bindAddress, bindPort)
+	pxeAddr := tlsAddr
+	// addr := fmt.Sprintf("%s:%s", bindAddress, bindPort)
 	client, err := datastore.NewClient(ctx, projectID)
-	if err != nil {
-		log.Fatalf("Failed to create new datastore client: %s", err)
-	}
+	rtx.Must(err, "Failed to create new datastore client")
+
 	dsCfg := storage.NewDatastoreConfig(client)
 	env := &handler.Env{
 		Config:                 dsCfg,
-		ServerAddr:             publicAddr,
+		ServerAddr:             publicHostname,
 		AllowForwardedRequests: allowForwardedRequests,
 	}
-	go setupMetricsHandler(dsCfg)
-	http.ListenAndServe(addr, newRouter(env))
+
+	go func() {
+		mux := setupMetricsHandler(dsCfg)
+		log.Fatal(http.ListenAndServe(":9090", mux))
+	}()
+
+	router := newRouter(env)
+	if service := os.Getenv("GAE_SERVICE"); service != "" {
+		// Assume we are running in AppEngine.
+		startAppEngineServerAsync(pxeAddr, router)
+	} else {
+		startTLSServerAsync(tlsAddr, router, publicHostname)
+	}
+
+	<-ctx.Done()
+
 }

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -76,6 +76,9 @@ var (
 	// bindPort may be set using the PORT environment variable.
 	bindPort = "8080"
 
+	// tlsPort may not be overridden.
+	tlsPort = "443"
+
 	// allowForwardedRequests controls how the ePoxy server evaluates and applies
 	// the Host IP whitelist to incoming requests.
 	// DEPRECATED.
@@ -248,8 +251,8 @@ func main() {
 		log.Fatalf("Environment variable PUBLIC_HOSTNAME must specify a public service name.")
 	}
 
-	tlsAddr := fmt.Sprintf("%s:%s", bindAddress, bindPort)
-	pxeAddr := tlsAddr
+	tlsAddr := fmt.Sprintf("%s:%s", bindAddress, tlsPort)
+	pxeAddr := fmt.Sprintf("%s:%s", bindAddress, bindPort)
 
 	client, err := datastore.NewClient(ctx, projectID)
 	rtx.Must(err, "Failed to create new datastore client")

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -241,7 +241,8 @@ func startTLSServerAsync(bindAddr string, router *mux.Router, hostname string) {
 }
 
 var (
-	// Create a unified context and a cancel method for main().
+	// Create a unified context and a cancel method for main(). Allows main to
+	// block until global context is canceled by integration tests.
 	ctx, cancelCtx = context.WithCancel(context.Background())
 )
 


### PR DESCRIPTION
This change preserves support for deployment to AppEngine until we complete the TLS-enabled server deployment to GCE. And, this change adds support for TLS-enabled server.

When not running on AppEngine, the TLS-enabled server allocates LetsEncrypt certificate on the stanard TLS port (443) and opens a second port for the iPXE client on port 4430.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/74)
<!-- Reviewable:end -->
