### PR TITLE
Add support for a storage reverse proxy to the epoxy server

### DIFF
--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -165,7 +165,7 @@ func newRouter(env *handler.Env) *mux.Router {
 
 	// Add proxy for accessing storage, such as GCS.
 	addRoute(router, "GET", "/v1/storage/{path:.*}",
-		http.HandlerFunc(env.HandleProxy))
+		http.HandlerFunc(env.HandleStorageProxy))
 	return router
 }
 

--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -85,8 +85,8 @@ var (
 	serverCert = os.Getenv("IPXE_CERT_FILE")
 	serverKey  = os.Getenv("IPXE_KEY_FILE")
 
-	// storagePrefixURL is the prefix URL for storage proxy requests. If empty, use
-	// a GCS URL constructed using the current GCLOUD_PROJECT.
+	// storagePrefixURL is the prefix URL for storage proxy requests. If empty, the
+	// storage proxy is disabled.
 	storagePrefixURL = os.Getenv("STORAGE_PREFIX_URL")
 )
 


### PR DESCRIPTION
This change adds support for a simple GET reverse proxy to the ePoxy server so that iPXE clients can request stage1 images using the ePoxy server's certificate.

This feature will only be useful for access to epoxy boot images, which are already public readable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/75)
<!-- Reviewable:end -->
