### PR TITLE
Add datastorex.Map property type & Add logging for all requests

### DIFF
--- a/datastorex/propertymap.go
+++ b/datastorex/propertymap.go
@@ -10,12 +10,16 @@ import (
 type Map map[string]string
 
 // Load allocates a new map and assignes key/values from each
-// datastore.Property. Every datastore.Property type must be string.
+// datastore.Property. Every datastore.Property type should be string.
+// Non-string types are ignored.
 func (mp *Map) Load(ps []datastore.Property) error {
 	*mp = make(map[string]string)
-	m := *mp
 	for _, p := range ps {
-		m[p.Name] = p.Value.(string)
+		s, ok := p.Value.(string)
+		// Silently skip any types that are not strings.
+		if ok {
+			(*mp)[p.Name] = s
+		}
 	}
 	return nil
 }

--- a/datastorex/propertymap.go
+++ b/datastorex/propertymap.go
@@ -5,6 +5,10 @@ import (
 	"cloud.google.com/go/datastore"
 )
 
+// TODO: If we move this package to github.com/m-lab/go, then we should change
+// the Map type to be more general (i.e. map[string]interface{}) or change the
+// type names to be more specific (i.e. StringMap).
+
 // Map implements the PropertyLoadSaver interface and provides a mechanism for
 // using `map[string]string` types in datastore entities.
 type Map map[string]string

--- a/datastorex/propertymap.go
+++ b/datastorex/propertymap.go
@@ -1,0 +1,33 @@
+// Package datastorex extends the cloud.google.com/go/datastore package.
+package datastorex
+
+import (
+	"cloud.google.com/go/datastore"
+)
+
+// Map implements the PropertyLoadSaver interface and provides a mechanism for
+// using `map[string]string` types in datastore entities.
+type Map map[string]string
+
+// Load allocates a new map and assignes key/values from each
+// datastore.Property. Every datastore.Property type must be string.
+func (mp *Map) Load(ps []datastore.Property) error {
+	*mp = make(map[string]string)
+	m := *mp
+	for _, p := range ps {
+		m[p.Name] = p.Value.(string)
+	}
+	return nil
+}
+
+// Save converts a Map to a slice of datastore properties.
+func (mp *Map) Save() ([]datastore.Property, error) {
+	var d []datastore.Property
+	for k, v := range *mp {
+		d = append(d, datastore.Property{
+			Name:  k,
+			Value: v,
+		})
+	}
+	return d, nil
+}

--- a/datastorex/propertymap_test.go
+++ b/datastorex/propertymap_test.go
@@ -18,6 +18,11 @@ func TestMap_Load(t *testing.T) {
 			Name:  "c",
 			Value: "d",
 		},
+		{
+			// Should be ignored.
+			Name:  "i",
+			Value: 100,
+		},
 	}
 
 	m := Map{}

--- a/datastorex/propertymap_test.go
+++ b/datastorex/propertymap_test.go
@@ -1,0 +1,56 @@
+// Package datastorex extends the cloud.google.com/go/datastore package.
+package datastorex
+
+import (
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/datastore"
+)
+
+func TestMap_Load(t *testing.T) {
+	ps := []datastore.Property{
+		{
+			Name:  "a",
+			Value: "b",
+		},
+		{
+			Name:  "c",
+			Value: "d",
+		},
+	}
+
+	m := Map{}
+	if err := m.Load(ps); err != nil {
+		t.Errorf("Map.Load() error = %v, want nil", err)
+	}
+
+	expected := Map{"a": "b", "c": "d"}
+	if !reflect.DeepEqual(m, expected) {
+		t.Errorf("Map.Load() got = %#v, want %#v", m, expected)
+	}
+}
+
+func TestMap_Save(t *testing.T) {
+	m := Map{"a": "b", "c": "d"}
+
+	got, err := m.Save()
+	if err != nil {
+		t.Errorf("Map.Save() error = %v, want nil", err)
+		return
+	}
+
+	expected := []datastore.Property{
+		{
+			Name:  "a",
+			Value: "b",
+		},
+		{
+			Name:  "c",
+			Value: "d",
+		},
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Map.Save() = %#v, want %#v", got, expected)
+	}
+}


### PR DESCRIPTION
This change adds logging for all requests (not natively available in the GCE VM environment now) and adds a new datastore property type `datastorex.Map` that implements the datastore PropertyLoadSaver interface that will allow a map type to be used in future changes to the epoxy Host datastore schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/84)
<!-- Reviewable:end -->
