### PR TITLE
Add gcsfuse support to preserve LetsEncrypt certs for epoxy server

### DIFF
--- a/cmd/epoxy_boot_server/main.go
+++ b/cmd/epoxy_boot_server/main.go
@@ -192,7 +192,7 @@ func setupLetsEncryptServer(addr string, r http.Handler, hostname string) *http.
 	// We will listen on standard TLS port using LetsEncrypt certificates.
 	m := &autocert.Manager{
 		// Certificates are cached to a local directory.
-		Cache: autocert.DirCache("autocert.cache"),
+		Cache: autocert.DirCache("/certs/autocert.cache"),
 		// The "Let's Encrypt Terms of Service" are accepted automatically.
 		Prompt: autocert.AcceptTOS,
 		// The ePoxy server will only accept TLS host requests from given hostname.

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -69,7 +69,7 @@ until docker run --rm --tty --volume /var/lib/toolbox:/tmp/go/bin \
    "go get -u github.com/googlecloudplatform/gcsfuse &&
     apt-get update --quiet=2 &&
     apt-get install --yes fuse &&
-    cp /bin/fusermount /tmp/go/bin"
+    cp /bin/fusermount /tmp/go/bin" ; do
   sleep 5
 done
 

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -54,15 +54,8 @@ cat <<EOF >startup.sh
 #!/bin/bash
 set -x
 mkdir "${CERTDIR}"
-# Copy certificates from GCS.
+# Build the GCS fuse user space tools.
 # Retry because docker fails to contact gcr.io sometimes.
-#until docker run --tty --volume "${CERTDIR}:${CERTDIR}" \
-#  gcr.io/cloud-builders/gsutil \
-#  cp gs://epoxy-${PROJECT}-private/server-certs.pem \
-#      gs://epoxy-${PROJECT}-private/server-key.pem \
-#      "${CERTDIR}"; do
-#  sleep 5
-#done
 until docker run --rm --tty --volume /var/lib/toolbox:/tmp/go/bin \
   --env "GOPATH=/tmp/go" \
   amd64/golang:1.11.5 /bin/bash -c \

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -102,7 +102,7 @@ gcloud compute instances create-with-container "${UPDATED_INSTANCE}" \
   --metadata-from-file "startup-script=startup.sh" \
   --network-interface network=mlab-platform-network,subnet=epoxy \
   --container-image "${CONTAINER}" \
-  --container-mount-host-path host-path=/home/epoxy/bucket,mount-path=/certs \
+  --container-mount-host-path host-path=${CERTDIR}/bucket,mount-path=/certs \
   --container-env-file config.env
 
 sleep 20


### PR DESCRIPTION
This change modifies the epoxy `deploy_epoxy_container.sh` to install the gcsfuse user space tools to mount the epoxy private gcs bucket within the epoxy server container to give the server access to certificates and write access to preserve the let's encrypt certificates across deployments.

To support bucket write permission, the deployment adds the storage-full scope to enable write access to GCS buckets. This change also changes the epoxy server directory to an absolute path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/87)
<!-- Reviewable:end -->
