### PR TITLE
Deploy ePoxy with complete network setup

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,4 +24,4 @@ steps:
    - 'ZONE_mlab_sandbox=us-west2-c'
    - 'ZONE_mlab_staging=us-central1-b'
    - 'ZONE_mlab_oti=us-east1-c'
-
+   - 'NETWORK=mlab-platform-network'

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -58,8 +58,8 @@ function find_lowest_network_number() {
 
   # List current network subnets, and extract the second octet from each.
   gcloud compute networks subnets list \
-        --network "${NETWORK}" --format "value(ipCidrRange)" "${ARGS[@]}" \
-        | cut -d. -f2 | sort -n > "${current_sequence}"
+    --network "${NETWORK}" --format "value(ipCidrRange)" "${ARGS[@]}" \
+    | cut -d. -f2 | sort -n > "${current_sequence}"
 
   # Generate a natural sequence from 0 to 255.
   seq 0 255 > "${natural_sequence}"


### PR DESCRIPTION
This change adds new stages to `epoxy_deploy_cotainer.sh` -- now in addition to creating the VM, the script will a) allocate a new subnet if one is not already found in the current region, b) allocate a static IP for the public IP, c) update the DNS zone for the epoxy-boot-api in the current project.

These steps are safe to perform multiple times.

The Cloud Builder service account must have adequate permissions to perform all of the above steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/88)
<!-- Reviewable:end -->
