### PR TITLE
Enable request IP verification for Stage1 JSON

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -175,13 +175,11 @@ func (env *Env) GenerateStage1JSON(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO(soltesz): re-enable once PLC updates are completed.
-	/* err = env.requestIsFromHost(req, host)
+	err = env.requestIsFromHost(req, host)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusForbidden)
 		return
 	}
-	*/
 
 	// TODO(soltesz):
 	// * Save information sent in PostForm.
@@ -250,7 +248,6 @@ func (env *Env) GenerateJSONConfig(rw http.ResponseWriter, req *http.Request) {
 // success or failure. In both cases, the session ids are invalidated. In all cases,
 // epoxy_client is expected to report the server's public host key.
 func (env *Env) ReceiveReport(rw http.ResponseWriter, req *http.Request) {
-	// TODO: Verify that the source IP maches the host IP.
 	// TODO: log or save values where appropriate.
 	req.ParseForm()
 
@@ -266,8 +263,6 @@ func (env *Env) ReceiveReport(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, err.Error(), http.StatusForbidden)
 		return
 	}
-
-	// TODO(soltesz):
 
 	// Verify sessionID matches the host record (i.e. request is authorized).
 	sessionID := mux.Vars(req)["sessionID"]

--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -465,7 +465,7 @@ func watchDownload(resp *grab.Response, update time.Duration) {
 			current := resp.BytesComplete()
 			log.Printf("  transferred %v / %v bytes (%.2f%%) at %.2f Mbps",
 				current,
-				resp.Size(),
+				resp.Size,
 				100*resp.Progress(),
 				float64(current-lastCount)/1.0e6/float64(update/time.Second))
 			lastCount = current

--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -465,7 +465,7 @@ func watchDownload(resp *grab.Response, update time.Duration) {
 			current := resp.BytesComplete()
 			log.Printf("  transferred %v / %v bytes (%.2f%%) at %.2f Mbps",
 				current,
-				resp.Size,
+				resp.Size(),
 				100*resp.Progress(),
 				float64(current-lastCount)/1.0e6/float64(update/time.Second))
 			lastCount = current


### PR DESCRIPTION
This change restores a check that was disabled while we booted through PLC nodes. The check was disabled to prevent clients from making requests over IPv6, which epoxy did not know about. Now the the PLC update is complete and that the epoxy server is IPv4 only, this should be safe to restore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/92)
<!-- Reviewable:end -->
