### PR TITLE
Updates Go to 1.15 for startup.sh.

### DIFF
--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -164,7 +164,7 @@ mkdir "${CERTDIR}"
 # Retry because docker fails to contact gcr.io sometimes.
 until docker run --rm --tty --volume /var/lib/toolbox:/tmp/go/bin \
   --env "GOPATH=/tmp/go" \
-  amd64/golang:1.11.5 /bin/bash -c \
+  golang:1.15 /bin/bash -c \
    "go get -u github.com/googlecloudplatform/gcsfuse &&
     apt-get update --quiet=2 &&
     apt-get install --yes fuse &&


### PR DESCRIPTION
I discovered recently while making some changes to [bootstraplib.sh in the k8s-support repo](https://github.com/m-lab/k8s-support/pull/508/files#diff-7387a43e3cf61fb7c3ec2f77b3ba05ece2f997c9ff2ffe79d9fa6408a33a0203R226 )that gcsfuse no longer builds against Go version less than 1.14. This PR updates the ePoxy VM deploy script to build gcsfuse in a Go 1.15 container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/96)
<!-- Reviewable:end -->
