### PR TITLE
Sends raw query string from client as part of data to extension

### DIFF
--- a/extension/request.go
+++ b/extension/request.go
@@ -45,6 +45,10 @@ type V1 struct {
 
 	// LastBoot is the most recent time when the booting machine reached stage1.
 	LastBoot time.Time `json:"last_boot"`
+
+	// The raw query string from the request to ePoxy. Extensions may use this
+	// to extract arbitrary data sent by the client.
+	RawQuery string `json:"raw_query"`
 }
 
 // Encode marshals a Request to JSON.

--- a/extension/request_test.go
+++ b/extension/request_test.go
@@ -36,6 +36,10 @@ func TestRequest_Encode(t *testing.T) {
 				Hostname:    "mlab4.lga0t.measurement-lab.org",
 				IPv4Address: "192.168.0.12",
 				LastBoot:    time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC),
+				// json.Marshal escapes '&' with '\u0026', which is why the
+				// "want" value below has that value instead of an actual
+				// ampersand: https://golang.org/pkg/encoding/json/#Marshal
+				RawQuery: "p=somevalue&z=othervalue",
 			},
 			want: dedent.Dedent(`
         {
@@ -43,7 +47,8 @@ func TestRequest_Encode(t *testing.T) {
                 "hostname": "mlab4.lga0t.measurement-lab.org",
                 "ipv4_address": "192.168.0.12",
                 "ipv6_address": "",
-                "last_boot": "2018-05-01T00:00:00Z"
+                "last_boot": "2018-05-01T00:00:00Z",
+                "raw_query": "p=somevalue\u0026z=othervalue"
             }
         }`),
 		},
@@ -75,13 +80,15 @@ func TestRequest_Decode(t *testing.T) {
                 "hostname": "mlab4.lga0t.measurement-lab.org",
                 "ipv4_address": "192.168.0.12",
                 "ipv6_address": "",
-                "last_boot": "2018-05-01T00:00:00Z"
+                "last_boot": "2018-05-01T00:00:00Z",
+                "raw_query": "p=somevalue\u0026z=othervalue"
             }
         }`))),
 			expected: &V1{
 				Hostname:    "mlab4.lga0t.measurement-lab.org",
 				IPv4Address: "192.168.0.12",
 				LastBoot:    time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC),
+				RawQuery:    "p=somevalue&z=othervalue",
 			},
 		},
 		{

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -357,11 +357,18 @@ func (env *Env) HandleExtension(rw http.ResponseWriter, req *http.Request) {
 		},
 	}
 
+	// Get the entire query from the original client request.
+	reqQuery := req.URL.RawQuery
+
 	extURL, err := url.Parse(storage.Extensions[operation])
 	if err != nil {
 		http.Error(rw, "Failed to parse extension URL for operation: "+operation, http.StatusInternalServerError)
 		return
 	}
+
+	// Append the entire query from the original request to the ePoxy request to
+	// the extension.
+	extURL.RawQuery = reqQuery
 
 	// TODO: track metrics about extension requests:
 	//  * histogram of request latencies,

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -354,21 +354,15 @@ func (env *Env) HandleExtension(rw http.ResponseWriter, req *http.Request) {
 			Hostname:    host.Name,
 			IPv4Address: host.IPv4Addr,
 			LastBoot:    host.LastSessionCreation,
+			RawQuery:    req.URL.RawQuery,
 		},
 	}
-
-	// Get the entire query from the original client request.
-	reqQuery := req.URL.RawQuery
 
 	extURL, err := url.Parse(storage.Extensions[operation])
 	if err != nil {
 		http.Error(rw, "Failed to parse extension URL for operation: "+operation, http.StatusInternalServerError)
 		return
 	}
-
-	// Append the entire query from the original request to the ePoxy request to
-	// the extension.
-	extURL.RawQuery = reqQuery
 
 	// TODO: track metrics about extension requests:
 	//  * histogram of request latencies,


### PR DESCRIPTION
ePoxy extensions may require specific data from the client (M-Lab nodes). Query parameters offer an easy and flexible way for clients to send arbitrary data to ePoxy extensions. This PR configures the ePoxy extension handler to to always include the raw query as a data field in data sent to an ePoxy extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/97)
<!-- Reviewable:end -->
