### PR TITLE
Changes assignment of runErr to var, not short declaration.

### DIFF
--- a/cmd/epoxy_client/main.go
+++ b/cmd/epoxy_client/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	for {
 		// Run the config loaded from the action URL.
-		runErr := c.Run(*flagAction, *flagAddKargs, *flagDryrun)
+		runErr = c.Run(*flagAction, *flagAddKargs, *flagDryrun)
 		if runErr != nil {
 			// Define a successful result.
 			result = "error: " + runErr.Error()


### PR DESCRIPTION
This PR resolves #98.

Currently, inside the `main()` function of epoxy_client, the variable `runErr` is defined with type `error`. However, inside the `for` loop `runErr` is assigned using short variable declaration syntax `runErr := <return value>`. This causes the [scope of the value of `runErr` to be limited to the `for` loop](https://golang.org/ref/spec#Declarations_and_scope) ([the innermost containing block):

> The scope of a constant or variable identifier declared inside a function begins at the end of the ConstSpec or VarSpec (ShortVarDecl for short variable declarations) and ends at the end of the innermost containing block.

When the `for` loop breaks, the conditional after it sees `runErr` as nil, so `reboot()` never gets called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/99)
<!-- Reviewable:end -->
