### PR TITLE
Adds new 'sync' operation to epoxy_admin

### DIFF
--- a/cmd/epoxy_admin/command/root.go
+++ b/cmd/epoxy_admin/command/root.go
@@ -62,6 +62,9 @@ var (
 
 	// List flags.
 	lfHostname string
+
+	// Sync flags.
+	sfSiteinfo string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/epoxy_admin/command/sync.go
+++ b/cmd/epoxy_admin/command/sync.go
@@ -49,6 +49,8 @@ EXAMPLE:
 	Run: runSync,
 }
 
+var lookupIP = net.LookupIP
+
 func runSync(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -98,7 +100,7 @@ func isHostnameInDatastore(hostname string, entities []*storage.Host) bool {
 // getV4Address returns the first IPv4 address it finds for a given hostname.
 func getV4Address(hostname string) (string, error) {
 	var addr string
-	addrs, err := net.LookupIP(hostname)
+	addrs, err := lookupIP(hostname)
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +114,7 @@ func getV4Address(hostname string) (string, error) {
 	}
 
 	if addr == "" {
-		return "", fmt.Errorf("Failed to get IPv4 address for host: %s", hostname)
+		return "", fmt.Errorf("failed to get IPv4 address for host: %s", hostname)
 	}
 	return addr, nil
 }

--- a/cmd/epoxy_admin/command/sync.go
+++ b/cmd/epoxy_admin/command/sync.go
@@ -1,0 +1,124 @@
+// Copyright 2021 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/datastore"
+
+	"github.com/m-lab/epoxy/storage"
+	"github.com/m-lab/go/rtx"
+
+	"github.com/spf13/cobra"
+)
+
+// syncCmd represents the sync command
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Syncs ePoxy Host records in Datastore with siteinfo",
+	Long: `
+USAGE:
+
+    Syncs all active hosts in siteinfo with the Datastore records for a
+    given project. The outcome should be that there are no sites in siteinfo for
+    which Datastore records do not exist. NOTE: sync does not remove Datastore
+    records for retired sites, but merely adds missing ones.
+
+EXAMPLE:
+
+    epoxy_admin sync --project mlab-sandbox
+`,
+	Run: runSync,
+}
+
+func runSync(cmd *cobra.Command, args []string) {
+	machineProjects := make(map[string]string)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// Get projects.json from siteinfo.
+	resp, err := http.Get(sfSiteinfo)
+	rtx.Must(err, "Failed to GET siteinfo URL: %s", sfSiteinfo)
+	siteinfo, err := ioutil.ReadAll(resp.Body)
+	rtx.Must(err, "Failed to read resp.Body from siteinfo request")
+	err = json.Unmarshal(siteinfo, &machineProjects)
+
+	// Setup Datastore client.
+	client, err := datastore.NewClient(ctx, fProject)
+	rtx.Must(err, "Failed to create new datastore client")
+
+	// Get all Datastore entities for the given project.
+	ds := storage.NewDatastoreConfig(client)
+	datastoreEntities, err := ds.List()
+	rtx.Must(err, "Failed to get Datastore entities")
+
+NEXTSITEINFO:
+	for machine, project := range machineProjects {
+		if project != fProject {
+			continue
+		}
+		hostname := fmt.Sprintf("%s.%s.measurement-lab.org", machine, project)
+		for _, entity := range datastoreEntities {
+			if hostname == entity.Name {
+				continue NEXTSITEINFO
+			}
+		}
+		cfHostname = hostname
+		v4, err := getV4Address(hostname)
+		rtx.Must(err, "ERROR")
+		cfAddress = v4
+
+		fmt.Printf("Adding host to Datastore: %s\n", hostname)
+		runCreate(cmd, args)
+	}
+}
+
+// getV4Address returns the first IPv4 address it finds for a given hostname.
+func getV4Address(hostname string) (string, error) {
+	var addr string
+	addrs, err := net.LookupIP(hostname)
+	if err != nil {
+		return "", fmt.Errorf("Failed to resolve host: %s", hostname)
+	}
+
+	for _, ip := range addrs {
+		if ip.To4() == nil {
+			continue
+		}
+		addr = ip.String()
+		break
+	}
+
+	if addr == "" {
+		return "", fmt.Errorf("Failed to get IPv4 address for host: %s", hostname)
+	}
+	return addr, nil
+}
+
+func init() {
+	rootCmd.AddCommand(syncCmd)
+
+	syncCmd.Flags().StringVar(&sfSiteinfo, "siteinfo",
+		"https://siteinfo.mlab-oti.measurementlab.net/v2/sites/projects.json",
+		"Absolute URL to siteinfo /v2/projects.json file.")
+}

--- a/cmd/epoxy_admin/command/sync_test.go
+++ b/cmd/epoxy_admin/command/sync_test.go
@@ -1,0 +1,137 @@
+// Copyright 2021 ePoxy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/m-lab/epoxy/storage"
+)
+
+func TestSync_getV4Address(t *testing.T) {
+	tests := []struct {
+		name     string
+		ips      []net.IP
+		err      error
+		expected string
+		wanterr  bool
+	}{
+		{
+			name: "one-ipv4",
+			ips: []net.IP{
+				net.ParseIP("2005:170:1100:6d::25"),
+				net.ParseIP("10.0.0.15"),
+			},
+			err:      nil,
+			expected: "10.0.0.15",
+			wanterr:  false,
+		},
+		{
+			name: "two-ipv4",
+			ips: []net.IP{
+				net.ParseIP("192.168.5.96"),
+				net.ParseIP("10.0.0.15"),
+			},
+			err:      nil,
+			expected: "192.168.5.96",
+			wanterr:  false,
+		},
+		{
+			name: "no-ipv4",
+			ips: []net.IP{
+				net.ParseIP("2005:1700:1100:6d::25"),
+				net.ParseIP("2903:f50b:4100::11"),
+				net.ParseIP("2022:2050:0:29::101"),
+			},
+			err:      nil,
+			expected: "",
+			wanterr:  true,
+		},
+		{
+			name:     "no-ips",
+			ips:      []net.IP{},
+			err:      fmt.Errorf("Host not found"),
+			expected: "",
+			wanterr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		lookupIP = func(host string) ([]net.IP, error) {
+			return tt.ips, tt.err
+		}
+		v4, err := getV4Address("fake-host")
+		if tt.wanterr {
+			if err == nil {
+				t.Errorf("getV4Address(): expected an error, but got: %v", err)
+			}
+		}
+		if v4 != tt.expected {
+			t.Errorf("getV4Address(): expected IPv4 %s, but got %s", tt.expected, v4)
+		}
+	}
+
+}
+
+func TestSync_isHostnameinDatastore(t *testing.T) {
+	entities := []*storage.Host{
+		{
+			Name: "mlab1-xyz0t.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			Name: "mlab3-lol05.mlab-staging.measurement-lab.org",
+		},
+		{
+			Name: "mlab2-abc01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			Name: "mlab4-usa02.mlab-staging.measurement-lab.org",
+		},
+		{
+			Name: "mlab1-xyz01.mlab-sandbox.measurement-lab.org",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		hostname string
+		found    bool
+	}{
+		{
+			name:     "found-hostname",
+			hostname: "mlab4-usa02.mlab-staging.measurement-lab.org",
+			found:    true,
+		},
+		{
+			name:     "not-found-hostname",
+			hostname: "mlab9-ddd01.mlab-staging.measurement-lab.org",
+			found:    false,
+		},
+		{
+			name:     "no-hostname",
+			hostname: "",
+			found:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		found := isHostnameInDatastore(tt.hostname, entities)
+		if found != tt.found {
+			t.Errorf("isHostnameInDatastore(): wanted %v, got %v", tt.found, found)
+		}
+	}
+}


### PR DESCRIPTION
Currently, creating ePoxy Datastore entities is a manual process for an operator, and potentially error prone because of this. This PR adds a new `sync` operation to the `epoxy_admin` utility which will download the production version of [projects.json from siteinfo](https://siteinfo.mlab-sandbox.measurementlab.net/v2/sites/projects.json), then gets all the current ePoxy Datastore entities and adds any missing entities. It intentionally does not attempt to remove any Datastore entities for sites that may have been removed from siteinfo.

The `sync` operation can be run manually, but is mostly intended to be run as part of [siteinfo builds](https://github.com/m-lab/siteinfo/blob/master/cloudbuild.yaml).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/101)
<!-- Reviewable:end -->
