### PR TITLE
Uses fProject var in default value for --siteinfo URL flag

### DIFF
--- a/cmd/epoxy_admin/command/sync.go
+++ b/cmd/epoxy_admin/command/sync.go
@@ -123,6 +123,6 @@ func init() {
 	rootCmd.AddCommand(syncCmd)
 
 	syncCmd.Flags().StringVar(&sfSiteinfo, "siteinfo",
-		"https://siteinfo.mlab-oti.measurementlab.net/v2/sites/projects.json",
+		"https://siteinfo."+fProject+".measurementlab.net/v2/sites/projects.json",
 		"Absolute URL to siteinfo /v2/projects.json file.")
 }


### PR DESCRIPTION
This PR configures the default value for the `--siteinfo` flag in sync.go to use the value from the `--project` flag. This will mean that, by default, the siteinfo URL will be the one for the project where the build is occurring. This should allow us to test new changes in sandbox branches of other repos that may depend on siteinfo and ePoxy Datastore entities in some way.

I wasn't at first 100% sure this would work, but looking over the [Go language spec for "Package initialization"](https://golang.org/ref/spec#Package_initialization) it appears that the compiler detects dependencies and initializes things in the necessary order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/102)
<!-- Reviewable:end -->
