### PR TITLE
Fix grab dependency path

### DIFF
--- a/nextboot/v1.go
+++ b/nextboot/v1.go
@@ -19,7 +19,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/cavaliercoder/grab"
+	grab "github.com/cavaliergopher/grab/v3"
 	"github.com/google/shlex"
 )
 


### PR DESCRIPTION
The gcp-config build builds a Docker image for epoxy.

This build is currently [broken](https://pantheon.corp.google.com/cloud-build/builds;region=global/b6c63f86-0fdf-402a-b30b-72fe6415d6de;step=2?project=581276032543) because epoxy's `github.com/cavaliergopher/grab` dependency [changed](https://github.com/cavaliergopher/grab/commit/3c0c4ad4410095fa5f8bab2396fb3e9ba84f7072) its path.

This PR fixes the path.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/107)
<!-- Reviewable:end -->
