### PR TITLE
Update go version to 1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@
 #  * test and build the Go code
 language: go
 go:
-- 1.15.x
+- 1.18.x
 go_import_path: github.com/m-lab/epoxy
 
 before_install:
-- go get github.com/mattn/goveralls
-- go get github.com/wadey/gocovmerge
+- go install github.com/mattn/goveralls@latest
+- go install github.com/wadey/gocovmerge@latest
 
 script:
 # Run "unit tests" with coverage.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM golang:1.15 as build
+FROM golang:1.18 as build
 
 # Add the local files to be sure we are building the local source code instead
 # of downloading from GitHub. All other package dependencies will be downloaded
 # from HEAD.
 ADD . /go/src/github.com/m-lab/epoxy
 ENV CGO_ENABLED 0
+ENV GO111MODULE=off
 WORKDIR /go/src/github.com/m-lab/epoxy
-RUN go get -t -v ./...
+RUN go get -d -t -v ./...
 RUN go test -v ./...
-RUN go get \
+RUN go install \
       -v \
       -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
       ./...

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -164,7 +164,7 @@ mkdir "${CERTDIR}"
 # Retry because docker fails to contact gcr.io sometimes.
 until docker run --rm --tty --volume /var/lib/toolbox:/tmp/go/bin \
   --env "GOPATH=/tmp/go" \
-  golang:1.15 /bin/bash -c \
+  golang:1.18 /bin/bash -c \
    "go get -u github.com/googlecloudplatform/gcsfuse &&
     apt-get update --quiet=2 &&
     apt-get install --yes fuse &&

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -165,7 +165,7 @@ mkdir "${CERTDIR}"
 until docker run --rm --tty --volume /var/lib/toolbox:/tmp/go/bin \
   --env "GOPATH=/tmp/go" \
   golang:1.18 /bin/bash -c \
-   "go install -u github.com/googlecloudplatform/gcsfuse@v0.41.1 &&
+   "go install github.com/googlecloudplatform/gcsfuse@v0.41.1 &&
     apt-get update --quiet=2 &&
     apt-get install --yes fuse &&
     cp /bin/fusermount /tmp/go/bin" ; do

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -165,7 +165,7 @@ mkdir "${CERTDIR}"
 until docker run --rm --tty --volume /var/lib/toolbox:/tmp/go/bin \
   --env "GOPATH=/tmp/go" \
   golang:1.18 /bin/bash -c \
-   "go get -u github.com/googlecloudplatform/gcsfuse &&
+   "go install -u github.com/googlecloudplatform/gcsfuse@v0.41.1 &&
     apt-get update --quiet=2 &&
     apt-get install --yes fuse &&
     cp /bin/fusermount /tmp/go/bin" ; do


### PR DESCRIPTION
Something in gcsfuse was updated, and installing it with go 1.15 did not work anymore due to the usage of `io/fs` (introduced in go1.16). This updates the go version used by Travis, the Dockerfile and the startup script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/108)
<!-- Reviewable:end -->
