### PR TITLE
Replaces token/bmc extension URLs with new extension server ones

### DIFF
--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -4,14 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////
 package storage
 
 import (
@@ -37,9 +37,10 @@ var (
 	// Extensions is a static map of operation names to extension URLS for testing.
 	// TODO: save/retrieve extension configuration in/from datastore.
 	Extensions = map[string]string{
-		"allocate_k8s_token": "http://token-server-platform-cluster.%s.measurementlab.net:8800/v1/allocate_k8s_token",
-		"bmc_store_password": "http://bmc-store-password-platform-cluster.%s.measurementlab.net:8801/v1/bmc_store_password",
-		"test_op":            "http://soltesz-epoxy-testing-instance-1.c.%s.internal:8001/operation",
+		"allocate_k8s_token":    "http://epoxy-extension-server.%s.measurementlab.net:8800/v1/allocate_k8s_token",
+		"allocate_k8s_token_v2": "http://epoxy-extension-server.%s.measurementlab.net:8800/v2/allocate_k8s_token",
+		"bmc_store_password":    "http://epoxy-extension-server.%s.measurementlab.net:8800/v1/bmc_store_password",
+		"test_op":               "http://soltesz-epoxy-testing-instance-1.c.%s.internal:8001/operation",
 	}
 )
 

--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -37,8 +37,7 @@ var (
 	// Extensions is a static map of operation names to extension URLS for testing.
 	// TODO: save/retrieve extension configuration in/from datastore.
 	Extensions = map[string]string{
-		"allocate_k8s_token":    "http://epoxy-extension-server.%s.measurementlab.net:8800/v1/allocate_k8s_token",
-		"allocate_k8s_token_v2": "http://epoxy-extension-server.%s.measurementlab.net:8800/v2/allocate_k8s_token",
+		"allocate_k8s_token":    "http://epoxy-extension-server.%s.measurementlab.net:8800/v2/allocate_k8s_token",
 		"bmc_store_password":    "http://epoxy-extension-server.%s.measurementlab.net:8800/v1/bmc_store_password",
 		"test_op":               "http://soltesz-epoxy-testing-instance-1.c.%s.internal:8001/operation",
 	}

--- a/storage/extensions.go
+++ b/storage/extensions.go
@@ -4,14 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// ////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
 package storage
 
 import (


### PR DESCRIPTION
There is now a ePoxy "extension server". Rather than running a separate Docker container on a separate port on each control plane node, there is now a single extension server which is a single Docker container and process, which listens on a single port. Additionally, there is now a V2 for the allocate_k8s_token extension, which doesn't just return a token but a JSON object with the token, the CA cert hash, and the URL of the API.

This PR changes the static URL mappings for extensions to use the the extension server, as well as V2 for the allocate_k8s_token extension.