### PR TITLE
Add epoxy_certs utility for certificate rotation

### DIFF
--- a/cmd/epoxy_certs/README.md
+++ b/cmd/epoxy_certs/README.md
@@ -50,5 +50,16 @@ Ideally, `epoxy_certs` would automatically append this file, but currently it do
 So, before deploying the server-cert.pem to a running server, append the ca-cert.pem.
 
 ```sh
-cat ca-cert.pem >> server-cert.pem
+cat server-cert.pem ca-cert.pem > server-certs.pem
 ```
+
+## M-Lab Deployments
+
+Upload the new certificates file to the private epoxy bucket:
+
+```sh
+gsutil cp server-key.pem server-certs.pem gs://epoxy-${PROJECT}-private/
+```
+
+Since these files are available to the epoxy server using GCSFuse, simply
+restart the epoxy server to load the new key.

--- a/cmd/epoxy_certs/README.md
+++ b/cmd/epoxy_certs/README.md
@@ -1,0 +1,37 @@
+# ePoxy Certificate Management
+
+The ePoxy server uses two certificate conventions:
+
+* Let's Encrypt certificates for Linux USB images (port 443) stage1+
+* Private CA certificates for iPXE firmware images (port 4430 (non-standard)) stage1-only.
+
+The Let's Encrypt certificates are updated automatically. The private CA
+certificate's expiration should outlast our hardware. However, because the iPXE
+firmware embeds the CA certificate, the server certificates need to be rotated
+periodically (every few years).
+
+## Check current certificates
+
+```sh
+$ echo \
+  | openssl s_client \
+      -servername epoxy-boot-api.mlab-sandbox.measurementlab.net \
+      -connect epoxy-boot-api.mlab-sandbox.measurementlab.net:4430 2>/dev/null \
+  | openssl x509 -text
+```
+
+## Generate Certificates
+
+Create new server certificates with 5 year expiration plus 30 extra days.
+
+```sh
+$ epoxy_certs server -hostname epoxy-boot-api.mlab-sandbox.measurementlab.net -duration $(( 5*8761 + 24*30 ))h
+$ openssl x509 -noout -text -in ./server-cert.pem
+Certificate:
+    Data:
+        ...
+        Validity
+            Not Before: Jan  2 22:09:15 2024 GMT
+            Not After : Feb  5 03:09:15 2029 GMT
+        ...
+```

--- a/cmd/epoxy_certs/README.md
+++ b/cmd/epoxy_certs/README.md
@@ -24,6 +24,10 @@ $ echo \
 
 Create new server certificates with 5 year expiration plus 30 extra days.
 
+> NOTE: you must have the CA certificate and private key files present to
+generate a new valid server certificate. The example below assumes default
+names, but you may specify alternate filenames with flags if needed.
+
 ```sh
 $ epoxy_certs server -hostname epoxy-boot-api.mlab-sandbox.measurementlab.net -duration $(( 5*8761 + 24*30 ))h
 $ openssl x509 -noout -text -in ./server-cert.pem

--- a/cmd/epoxy_certs/README.md
+++ b/cmd/epoxy_certs/README.md
@@ -62,4 +62,4 @@ gsutil cp server-key.pem server-certs.pem gs://epoxy-${PROJECT}-private/
 ```
 
 Since these files are available to the epoxy server using GCSFuse, simply
-restart the epoxy server to load the new key.
+restart or redeploy the epoxy server to load the new key.

--- a/cmd/epoxy_certs/README.md
+++ b/cmd/epoxy_certs/README.md
@@ -38,7 +38,7 @@ Certificate:
 
 ## Updating Server Certificates
 
-The iPXE client requires that both the server and CA certificate both be present
+The iPXE client requires that the server and CA certificate both be present
 in the server certificate file.
 
 Ideally, `epoxy_certs` would automatically append this file, but currently it does not.

--- a/cmd/epoxy_certs/README.md
+++ b/cmd/epoxy_certs/README.md
@@ -35,3 +35,16 @@ Certificate:
             Not After : Feb  5 03:09:15 2029 GMT
         ...
 ```
+
+## Updating Server Certificates
+
+The iPXE client requires that both the server and CA certificate both be present
+in the server certificate file.
+
+Ideally, `epoxy_certs` would automatically append this file, but currently it does not.
+
+So, before deploying the server-cert.pem to a running server, append the ca-cert.pem.
+
+```sh
+cat ca-cert.pem >> server-cert.pem
+```

--- a/cmd/epoxy_certs/certutil.go
+++ b/cmd/epoxy_certs/certutil.go
@@ -1,4 +1,4 @@
-// Package certutil implements utility methods for managing x509 certificates and RSA keys.
+// Package main implements utility methods for managing x509 certificates and RSA keys.
 package main
 
 import (

--- a/cmd/epoxy_certs/certutil.go
+++ b/cmd/epoxy_certs/certutil.go
@@ -1,0 +1,135 @@
+// Package certutil implements utility methods for managing x509 certificates and RSA keys.
+package main
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+)
+
+var ErrNoCertFound = errors.New("no cert found")
+
+// NewCertPool creates a new x509.CertPool from all PEM encoded certificates in pemFile.
+func NewCertPool(pemFile string) (*x509.CertPool, error) {
+	pemBytes, err := os.ReadFile(pemFile)
+	if err != nil {
+		return nil, err
+	}
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(pemBytes); !ok {
+		return nil, fmt.Errorf("no certificates loaded from %s", pemFile)
+	}
+	return certPool, nil
+}
+
+// ReadCertFile reads a PEM encoded certificate from certFile.
+func ReadCertFileOld(certFile string) (*x509.Certificate, error) {
+	derBytes, err := readPEMFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
+}
+
+type CertReader struct {
+	err error
+}
+
+func (cr *CertReader) readFile(f string) []byte {
+	pemBytes, err := os.ReadFile(f)
+	if err != nil {
+		cr.err = err
+	}
+	return pemBytes
+}
+
+func (cr *CertReader) decode(p []byte) []byte {
+	if cr.err != nil {
+		return nil
+	}
+	block, _ := pem.Decode(p)
+	if block == nil {
+		cr.err = ErrNoCertFound
+		return nil
+	}
+	return block.Bytes
+}
+
+func (cr *CertReader) parseCertificate(b []byte) *x509.Certificate {
+	if cr.err != nil {
+		return nil
+	}
+	cert, err := x509.ParseCertificate(b)
+	if err != nil {
+		cr.err = err
+	}
+	return cert
+}
+
+func ReadCertFile(certFile string) (*x509.Certificate, error) {
+	cr := &CertReader{}
+	cert := cr.parseCertificate(cr.decode(cr.readFile(certFile)))
+	return cert, cr.err
+}
+
+// WriteCertFile writes a PEM encoded certificate to certFile.
+func WriteCertFile(derBytes []byte, certFile string) error {
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return err
+	}
+	defer certOut.Close()
+	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadRSAKeyFile reads a PEM encoded, PKCS1 format private RSA key from keyFile.
+func ReadRSAKeyFile(keyFile string) (*rsa.PrivateKey, error) {
+	derBytes, err := readPEMFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	key, err := x509.ParsePKCS1PrivateKey(derBytes)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// WriteRSAKeyFile writes a PEM encoded, PKCS1 format private RSA key to keyFile.
+func WriteRSAKeyFile(privKey *rsa.PrivateKey, keyFile string) error {
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		return err
+	}
+	defer keyOut.Close()
+	err = pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privKey)})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// readPEMFile returns the first PEM block from pemFile.
+func readPEMFile(pemFile string) ([]byte, error) {
+	pemBytes, err := os.ReadFile(pemFile)
+	if err != nil {
+		return nil, err
+	}
+	// Only read the first block.
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %s", pemFile)
+	}
+	return block.Bytes, nil
+}

--- a/cmd/epoxy_certs/main.go
+++ b/cmd/epoxy_certs/main.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var helpMessage = `NAME:
+  epoxycerts - A tool for creating TLS certificates for the ePoxy server and
+  clients.
+
+DESCRIPTION:
+  The ePoxy system uses a private root CA. This CA is used to issue all
+  server and client certificates.
+
+  For better security, the root CA should be kept offline.
+
+EXAMPLES:
+  epoxy_certs ca --hostname ca.example.com
+
+  epoxy_certs server --hostname server.example.com
+
+  epoxy_certs clientca --hostname client-ca.example.com
+
+  epoxy_certs client --hostname client1.example.com
+
+USAGE:
+`
+
+var Usage = func() {
+	fmt.Fprint(os.Stderr, helpMessage)
+	flag.PrintDefaults()
+}
+
+func init() {
+	flag.Usage = Usage
+}
+
+var (
+	// cert creation.
+	hostname       = flag.String("hostname", "", "A single hostname (or IP) for the certificate CommonName.")
+	extraHostnames = flag.String("extraNames", "", "Comma-separated list of hostnames or IPs in addition to hostname.")
+	startDate      = flag.String("start-date", "", "Date when certificate becomes valid. Format as: Jan 1 15:04:05 2011")
+	validFor       = flag.Duration("duration", 365*24*time.Hour, "Duration that the certificate will be valid.")
+	orgName        = flag.String("org-name", "", "Name of organization that uses this certificate.")
+	bitSize        = flag.Int("bit-size", 2048, "Size of RSA key to generate.")
+
+	caCertFile = flag.String("ca-cert", "ca-cert.pem", "The CA certificate in PEM format.")
+	caKeyFile  = flag.String("ca-key", "ca-key.pem", "The CA private key in PEM format.")
+
+	serverCertFile = flag.String("server-cert", "server-cert.pem", "The server certificate in PEM format.")
+	serverKeyFile  = flag.String("server-key", "server-key.pem", "The server private key in PEM format.")
+
+	clientIssuerCertFile = flag.String("clientca-cert", "clientca-cert.pem", "The client issuer certificate in PEM format.")
+	clientIssuerKeyFile  = flag.String("clientca-key", "clientca-key.pem", "The client issuer private key in PEM format.")
+
+	clientCertFile = flag.String("client-cert", "client-cert.pem", "The client certificate in PEM format.")
+	clientKeyFile  = flag.String("client-key", "client-key.pem", "The client private key in PEM format.")
+)
+
+func checkFlags() string {
+	// Replaces flag.Parse()
+	if len(os.Args) == 1 || os.Args[1][0] == '-' {
+		flag.Usage()
+		os.Exit(1)
+	}
+	opt := os.Args[1]
+	flag.CommandLine.Parse(os.Args[2:])
+
+	// Check for required values.
+	if len(*hostname) == 0 && opt != "ca" {
+		log.Fatalf("Missing required --hostname parameter.")
+	}
+	return opt
+}
+
+func parseStartDate(startDate string) (notBefore time.Time) {
+	if len(startDate) == 0 {
+		notBefore = time.Now()
+		// Subtract 24 hours to prevent "certificate not yet valid" authentication errors.
+		notBefore = notBefore.Add(-48 * time.Hour)
+	} else {
+		var err error
+		notBefore, err = time.Parse("Jan 2 15:04:05 2006", startDate)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to parse creation date: %s\n", err)
+			os.Exit(1)
+		}
+	}
+	return
+}
+
+func addHostsToCertificate(cert *x509.Certificate, hostnames []string) {
+	for _, h := range hostnames {
+		if len(h) == 0 {
+			continue
+		}
+		if ip := net.ParseIP(h); ip != nil {
+			cert.IPAddresses = append(cert.IPAddresses, ip)
+		} else {
+			cert.DNSNames = append(cert.DNSNames, h)
+		}
+	}
+}
+
+func getSerialNumber() *big.Int {
+	// TODO: what's a better value here?
+	t := time.Now()
+	serialStr := fmt.Sprintf("%04d%02d%02d%02d%02d%02d", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
+	serialNumber, err := strconv.ParseInt(serialStr, 10, 64)
+	if err != nil {
+		log.Fatalf("Failed to generate serial number from %s: %s", serialStr, err)
+	}
+	return big.NewInt(serialNumber)
+}
+
+func getBasicCertificate(hostname string, extraHostnames []string) (c *x509.Certificate) {
+	notBefore := parseStartDate(*startDate)
+	c = &x509.Certificate{
+		SerialNumber: getSerialNumber(),
+		Subject: pkix.Name{
+			Organization: []string{*orgName},
+		},
+
+		NotBefore: notBefore,
+		NotAfter:  notBefore.Add(*validFor),
+
+		BasicConstraintsValid: true,
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+	}
+	if len(hostname) != 0 {
+		c.Subject.CommonName = hostname
+		addHostsToCertificate(c, []string{hostname})
+	}
+	addHostsToCertificate(c, extraHostnames)
+	return
+}
+
+func selfSignCert(c *x509.Certificate, certFile, keyFile string) {
+	newPrivKey, err := rsa.GenerateKey(rand.Reader, *bitSize)
+	if err != nil {
+		log.Fatalf("Failed to generate private key: %s", err)
+	}
+
+	derBytesCert, err := x509.CreateCertificate(rand.Reader, c, c, &newPrivKey.PublicKey, newPrivKey)
+	if err != nil {
+		log.Fatalf("Failed to xcreate certificate: %s", err)
+	}
+
+	// Write cert and key to file.
+	WriteCertFile(derBytesCert, certFile)
+	WriteRSAKeyFile(newPrivKey, keyFile)
+}
+
+func signCert(c *x509.Certificate, certFile, keyFile, signerCertFile, signerKeyFile string) {
+	signerCert, err := ReadCertFile(signerCertFile)
+	if err != nil {
+		log.Fatalf("Failed to read signer certificate: %s", err)
+	}
+
+	signerKey, err := ReadRSAKeyFile(signerKeyFile)
+	if err != nil {
+		log.Fatalf("Failed to read signer private key: %s", err)
+	}
+
+	newPrivKey, err := rsa.GenerateKey(rand.Reader, *bitSize)
+	if err != nil {
+		log.Fatalf("Failed to generate private key: %s", err)
+	}
+
+	// Create a certificate signed by the signer.
+	derBytesCert, err := x509.CreateCertificate(rand.Reader, c, signerCert, &newPrivKey.PublicKey, signerKey)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %s", err)
+	}
+
+	// Write cert to file.
+	WriteCertFile(derBytesCert, certFile)
+	WriteRSAKeyFile(newPrivKey, keyFile)
+}
+
+func createRootCACert(c *x509.Certificate) {
+	c.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	c.IsCA = true
+	// Allow one intermediate CA below the root CA for issuing client certificates.
+	c.MaxPathLen = 1
+
+	selfSignCert(c, *caCertFile, *caKeyFile)
+}
+
+func createServerCert(c *x509.Certificate) {
+	c.KeyUsage = x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
+	c.ExtKeyUsage = append(c.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+
+	signCert(c, *serverCertFile, *serverKeyFile, *caCertFile, *caKeyFile)
+}
+
+func createIssuerClientCert(c *x509.Certificate) {
+	c.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	c.IsCA = true
+	// Restrict this certificate to only issuing certificates.
+	c.MaxPathLenZero = true
+
+	signCert(c, *clientIssuerCertFile, *clientIssuerKeyFile, *caCertFile, *caKeyFile)
+}
+
+func createClientCert(c *x509.Certificate) {
+	c.ExtKeyUsage = append(c.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+
+	signCert(c, *clientCertFile, *clientKeyFile, *clientIssuerCertFile, *clientIssuerKeyFile)
+}
+
+func main() {
+	opt := checkFlags()
+
+	c := getBasicCertificate(*hostname, strings.Split(*extraHostnames, ","))
+	switch opt {
+	case "ca":
+		createRootCACert(c)
+	case "clientca":
+		createIssuerClientCert(c)
+	case "client":
+		createClientCert(c)
+	case "server":
+		createServerCert(c)
+	default:
+		flag.Usage()
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This change adds a new utility for creating a private ca for the boot server and rotating the epoxy server certificates.

The logic in this PR is identical to that used to originally generate the current epoxy private ca server certificates, with minor changes for style and lint warnings. Taken directly from https://github.com/stephen-soltesz/epoxy/blob/master/src/epoxy/cmd/epoxycerts/main.go

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/113)
<!-- Reviewable:end -->
