### PR TITLE
Launch ePoxy container from startup-script instead of with "create-with-container"

### DIFF
--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -206,6 +206,8 @@ STORAGE_PREFIX_URL=https://storage.googleapis.com/epoxy-${PROJECT}
 GCLOUD_PROJECT=${PROJECT}
 EOF3
 
+gcloud auth configure-docker gcr.io --quiet
+
 docker run --env-file ./config.env --volume ${CERTDIR}/bucket:/certs \
   --restart always --name "${UPDATED_INSTANCE}" "${CONTAINER}"
 EOF

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -235,7 +235,9 @@ gcloud compute instances create "${UPDATED_INSTANCE}" \
   --tags allow-epoxy-ports \
   --scopes cloud-platform \
   --metadata-from-file "startup-script=startup.sh" \
-  --network-interface network=mlab-platform-network,subnet=epoxy
+  --network-interface network=mlab-platform-network,subnet=epoxy \
+  --image-family debian-13 \
+  --image-project debian-cloud
 
 sleep 20
 TEMP_IP=$(

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -166,7 +166,7 @@ mkdir "${CERTDIR}"
 #
 # Add Docker's official GPG key:
 apt update
-apt install ca-certificates curl
+apt install --yes ca-certificates curl
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc
@@ -179,7 +179,7 @@ Components: stable
 Signed-By: /etc/apt/keyrings/docker.asc
 EOF2
 sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo apt install --yes docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Build the GCS fuse user space tools.
 # Retry because docker fails to contact gcr.io sometimes.

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -210,7 +210,7 @@ gcloud auth configure-docker gcr.io --quiet
 
 docker run --env-file ./config.env --volume ${CERTDIR}/bucket:/certs \
   --restart always --name "${UPDATED_INSTANCE}" --network host \
-  "${CONTAINER}"
+  --detach "${CONTAINER}"
 EOF
 
 
@@ -235,7 +235,7 @@ gcloud compute instances create "${UPDATED_INSTANCE}" \
   --tags allow-epoxy-ports \
   --scopes cloud-platform \
   --metadata-from-file "startup-script=startup.sh" \
-  --network-interface network=mlab-platform-network,subnet=epoxy \
+  --network-interface network=mlab-platform-network,subnet=epoxy
 
 sleep 20
 TEMP_IP=$(

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -197,19 +197,19 @@ mkdir ${CERTDIR}/bucket
 export PATH=\$PATH:/var/lib/toolbox
 /var/lib/toolbox/gcsfuse --implicit-dirs -o rw,allow_other \
   epoxy-${PROJECT}-private ${CERTDIR}/bucket
-EOF
 
-cat <<EOF >config.env
+cat <<EOF3 >config.env
 IPXE_CERT_FILE=/certs/server-certs.pem
 IPXE_KEY_FILE=/certs/server-key.pem
 PUBLIC_HOSTNAME=epoxy-boot-api.${PROJECT}.measurementlab.net
 STORAGE_PREFIX_URL=https://storage.googleapis.com/epoxy-${PROJECT}
 GCLOUD_PROJECT=${PROJECT}
+EOF3
 
-# docker run --env-file ./config.env --volume ${CERTDIR}/bucket:/certs \
+docker run --env-file ./config.env --volume ${CERTDIR}/bucket:/certs \
   --restart always --name "${UPDATED_INSTANCE}" "${CONTAINER}"
-
 EOF
+
 
 CURRENT_FIREWALL=$(
   gcloud compute firewall-rules list \

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -174,7 +174,7 @@ chmod a+r /etc/apt/keyrings/docker.asc
 tee /etc/apt/sources.list.d/docker.sources <<EOF2
 Types: deb
 URIs: https://download.docker.com/linux/debian
-Suites: $(. /etc/os-release && echo "\$VERSION_CODENAME}")
+Suites: \$(. /etc/os-release && echo "\$VERSION_CODENAME")
 Components: stable
 Signed-By: /etc/apt/keyrings/docker.asc
 EOF2

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -230,7 +230,7 @@ gcloud compute instances create "${UPDATED_INSTANCE}" \
   --project "${PROJECT}" \
   --zone "${ZONE}" \
   --tags allow-epoxy-ports \
-  --scopes default,datastore,storage-full \
+  --scopes cloud-platform \
   --metadata-from-file "startup-script=startup.sh" \
   --network-interface network=mlab-platform-network,subnet=epoxy \
 

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -168,13 +168,13 @@ mkdir "${CERTDIR}"
 apt update
 apt install --yes ca-certificates curl
 install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc
 # Add the repository to Apt sources:
 tee /etc/apt/sources.list.d/docker.sources <<EOF2
 Types: deb
-URIs: https://download.docker.com/linux/ubuntu
-Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+URIs: https://download.docker.com/linux/debian
+Suites: $(. /etc/os-release && echo "\$VERSION_CODENAME}")
 Components: stable
 Signed-By: /etc/apt/keyrings/docker.asc
 EOF2

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -184,6 +184,10 @@ IPXE_KEY_FILE=/certs/server-key.pem
 PUBLIC_HOSTNAME=epoxy-boot-api.${PROJECT}.measurementlab.net
 STORAGE_PREFIX_URL=https://storage.googleapis.com/epoxy-${PROJECT}
 GCLOUD_PROJECT=${PROJECT}
+
+# docker run --env-file ./config.env --volume ${CERTDIR}/bucket:/certs \
+  --restart always --name "${UPDATED_INSTANCE}" "${CONTAINER}"
+
 EOF
 
 CURRENT_FIREWALL=$(
@@ -201,16 +205,13 @@ if [[ -z "${CURRENT_FIREWALL}" ]]; then
 fi
 
 # Create new VM with ephemeral public IP.
-gcloud compute instances create-with-container "${UPDATED_INSTANCE}" \
+gcloud compute instances create "${UPDATED_INSTANCE}" \
   --project "${PROJECT}" \
   --zone "${ZONE}" \
   --tags allow-epoxy-ports \
   --scopes default,datastore,storage-full \
   --metadata-from-file "startup-script=startup.sh" \
   --network-interface network=mlab-platform-network,subnet=epoxy \
-  --container-image "${CONTAINER}" \
-  --container-mount-host-path host-path=${CERTDIR}/bucket,mount-path=/certs \
-  --container-env-file config.env
 
 sleep 20
 TEMP_IP=$(

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -160,6 +160,27 @@ cat <<EOF >startup.sh
 #!/bin/bash
 set -x
 mkdir "${CERTDIR}"
+
+#
+# Install Docker
+#
+# Add Docker's official GPG key:
+apt update
+apt install ca-certificates curl
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+# Add the repository to Apt sources:
+tee /etc/apt/sources.list.d/docker.sources <<EOF2
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+Components: stable
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF2
+sudo apt update
+sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
 # Build the GCS fuse user space tools.
 # Retry because docker fails to contact gcr.io sometimes.
 until docker run --rm --tty --volume /var/lib/toolbox:/tmp/go/bin \

--- a/deploy_epoxy_container.sh
+++ b/deploy_epoxy_container.sh
@@ -209,7 +209,8 @@ EOF3
 gcloud auth configure-docker gcr.io --quiet
 
 docker run --env-file ./config.env --volume ${CERTDIR}/bucket:/certs \
-  --restart always --name "${UPDATED_INSTANCE}" "${CONTAINER}"
+  --restart always --name "${UPDATED_INSTANCE}" --network host \
+  "${CONTAINER}"
 EOF
 
 


### PR DESCRIPTION
GCP is discontinuing the feature of being able to create GCE VMs and have a container process automatically launch:

https://docs.cloud.google.com/compute/docs/containers/migrate-containers

The changes in the PR remove the `create-with-container` option from the gcloud command that created the ePoxy boot server VM, and adds equivalent functionality into the startup-script, which already existed for other purposes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy/114)
<!-- Reviewable:end -->
